### PR TITLE
Use a plus sign rather than caret for activity panels

### DIFF
--- a/frontend/client/res/templates/record/side.tpl
+++ b/frontend/client/res/templates/record/side.tpl
@@ -5,7 +5,7 @@
         <div class="pull-right btn-group">
             {{#if actions}}
                 <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
-                    <span class="caret"></span>
+                    <span class="glyphicon glyphicon-plus"></span>
                 </button>
                 <ul class="dropdown-menu">
                     {{#each actions}}


### PR DESCRIPTION
I think a plus sign makes more sense for users, as these menus are used only to create new activities against the entity.
