### PR TITLE
Fix: use semi-colon instead of commas to seperate email addresses in to,...

### DIFF
--- a/frontend/client/src/views/email/detail.js
+++ b/frontend/client/src/views/email/detail.js
@@ -80,13 +80,13 @@ Espo.define('Views.Email.Detail', 'Views.Detail', function (Dep) {
             
             if (cc) {
                 attributes['cc'] = this.model.get('cc');
-                (this.model.get('to')).split(',').forEach(function (item) {
+                (this.model.get('to')).split(';').forEach(function (item) {
                    item = item.trim();
                    if (item != this.getUser().get('emailAddress')) {
-                       attributes['cc'] += ', ' + item;
+                       attributes['cc'] += '; ' + item;
                    }
                 }, this);
-                attributes['cc'] = attributes['cc'].replace(/^(\, )/,"");
+                attributes['cc'] = attributes['cc'].replace(/^(\; )/,"");
             }
             
             if (this.model.get('parentId')) {


### PR DESCRIPTION
... cc fields

Sorry about this, this also means the email addresses are correctly displayed in the compose modal.
