### PR TITLE
INSERTing number fix for PhoneNumber.php

### DIFF
--- a/application/Espo/Repositories/PhoneNumber.php
+++ b/application/Espo/Repositories/PhoneNumber.php
@@ -224,7 +224,7 @@ class PhoneNumber extends \Espo\Core\ORM\Repositories\RDB
                                 ".$pdo->quote($entity->id).",
                                 ".$pdo->quote($entity->getEntityName()).",
                                 ".$pdo->quote($phoneNumber->id).",
-                                ".$pdo->quote($number === $primary)."
+                                ".$pdo->quote((int)($number === $primary))."
                             )
                     ";
                     $sth = $pdo->prepare($query);


### PR DESCRIPTION
Adding a new phone number to a contact was giving the error: SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'primary' at row 1

Cast the boolean to an int and it appears to be fixed.