### PR TITLE
Relation between Emails and Contacts

### DIFF
--- a/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Contact.json
+++ b/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Contact.json
@@ -209,7 +209,7 @@
         },
         "emails": {
             "type": "hasChildren",
-            "entity": "Task",
+            "entity": "Email",
             "foreign": "parent",
             "layoutRelationshipsDisabled": true
         },

--- a/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Email.json
+++ b/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Email.json
@@ -11,7 +11,7 @@
             "entity": "Account"
         },
         "parent": {
-            "entityList": ["Account", "Lead", "Opportunity", "Case"]
+            "entityList": ["Account", "Contact", "Lead", "Opportunity", "Case"]
         }
     }
 }


### PR DESCRIPTION
There were two small bugs in the relation between emails and contacts:
* in the contact entity, the relation to email was wrong due to a copy & paste misstake
* in the email entity, contact was not allowed as parent entity