### PR TITLE
FIX: Couldn't add unique index due to prior duplicates

### DIFF
--- a/application/Espo/Core/Utils/Database/DBAL/Platforms/MySqlPlatform.php
+++ b/application/Espo/Core/Utils/Database/DBAL/Platforms/MySqlPlatform.php
@@ -261,7 +261,7 @@ class MySqlPlatform extends \Doctrine\DBAL\Platforms\MySqlPlatform
             return $this->getCreatePrimaryKeySQL($index, $table);
         }
 
-        $query = 'CREATE ' . $this->getCreateIndexSQLFlags($index) . 'INDEX ' . $name . ' ON ' . $this->espoQuote($table);
+        $query = 'ALTER IGNORE TABLE '. $this->espoQuote($table) . ' ADD ' . $this->getCreateIndexSQLFlags($index) . ' INDEX ' . $name;
         $query .= ' (' . $this->getIndexFieldDeclarationListSQL($columns) . ')';
 
         return $query;


### PR DESCRIPTION
In the slim chance that duplicates already existed, it's impossible to rebuild an old database.

(Happened to me earlier this year)