### PR TITLE
Add CONCAT function to the base query class

### DIFF
--- a/application/Espo/ORM/DB/Query/Base.php
+++ b/application/Espo/ORM/DB/Query/Base.php
@@ -288,6 +288,9 @@ abstract class Base
                 if (stripos($field[0], 'VALUE:') === 0) {
                     $part = substr($field[0], 6);
                     $part = $this->quote($part);
+                } else if (stripos($field[0], 'CONCAT:') === 0) {
+                    $part = substr($field[0], 7);
+                    $part = 'CONCAT(' . $part . ')';
                 } else {
                     $part = $this->convertComplexExpression($entity, $field[0], $distinct);
                 }


### PR DESCRIPTION
just an idea, then we can using it like this:
```php
        $selectParams = array(
            'select' => [
                .........................
                ['VALUE:', 'dateEndDate'],
                ['CONCAT:users.first_name, " ", users.last_name','assignedUserName'],
                ................
            ],
            'leftJoins' => ['users'],
            'whereClause' => .................
```