### PR TITLE
Fast filtering in list views

### DIFF
--- a/client/src/views/fields/array.js
+++ b/client/src/views/fields/array.js
@@ -247,6 +247,9 @@ Espo.define('views/fields/array', ['views/fields/base', 'lib!Selectize'], functi
                     };
                 }
             });
+            this.$element.on('change', function () {
+                this.trigger('change');
+            }.bind(this));
         },
 
         fetchFromDom: function () {

--- a/client/src/views/fields/base.js
+++ b/client/src/views/fields/base.js
@@ -223,6 +223,9 @@ Espo.define('views/fields/base', 'view', function (Dep) {
                 this.searchParams = _.clone(this.options.searchParams || {});
                 this.searchData = {};
                 this.setupSearch();
+                this.listenTo(this, 'change', function() {
+                    this._parentView.trigger('change');
+                });
             }
 
             this.on('invalid', function () {
@@ -352,7 +355,7 @@ Espo.define('views/fields/base', 'view', function (Dep) {
 
         initElement: function () {
             this.$element = this.$el.find('[name="' + this.name + '"]');
-            if (this.mode == 'edit') {
+            if (this.mode == 'edit' || this.mode == 'search') {
                 this.$element.on('change', function () {
                     this.trigger('change');
                 }.bind(this));

--- a/client/src/views/fields/date.js
+++ b/client/src/views/fields/date.js
@@ -114,9 +114,19 @@ Espo.define('views/fields/date', 'views/fields/base', function (Dep) {
         afterRender: function () {
             if (this.mode == 'edit' || this.mode == 'search') {
                 this.$element = this.$el.find('[name="' + this.name + '"]');
+                this.$additionalElement = this.$el.find('div.additional-number');
 
                 var wait = false;
                 this.$element.on('change', function () {
+                    if (!wait) {
+                        this.trigger('change');
+                        wait = true;
+                        setTimeout(function () {
+                            wait = false
+                        }, 100);
+                    }
+                }.bind(this));
+                this.$additionalElement.on('change', function () {
                     if (!wait) {
                         this.trigger('change');
                         wait = true;
@@ -188,6 +198,7 @@ Espo.define('views/fields/date', 'views/fields/base', function (Dep) {
                 this.$el.find('div.primary').removeClass('hidden');
                 this.$el.find('div.additional').removeClass('hidden');
             }
+            this.trigger('change');
         },
 
         parseDate: function (string) {

--- a/client/src/views/fields/enum.js
+++ b/client/src/views/fields/enum.js
@@ -189,6 +189,10 @@ Espo.define('views/fields/enum', ['views/fields/base', 'lib!Selectize'], functio
                         };
                     }
                 });
+
+                this.$element.on('change', function () {
+                    this.trigger('change');
+                }.bind(this));
             }
         },
 

--- a/client/src/views/fields/link-parent.js
+++ b/client/src/views/fields/link-parent.js
@@ -159,6 +159,7 @@ Espo.define('views/fields/link-parent', 'views/fields/base', function (Dep) {
             } else {
                 this.$el.find('div.primary').addClass('hidden');
             }
+            this.trigger('change');
         },
 
         select: function (model) {

--- a/client/src/views/fields/link.js
+++ b/client/src/views/fields/link.js
@@ -186,6 +186,7 @@ Espo.define('views/fields/link', 'views/fields/base', function (Dep) {
             } else {
                 this.$el.find('div.one-of-container').addClass('hidden');
             }
+            this.trigger('change');
         },
 
         getAutocompleteUrl: function () {
@@ -357,6 +358,7 @@ Espo.define('views/fields/link', 'views/fields/base', function (Dep) {
                 this.searchParams.oneOfIdList.splice(index, 1);
             }
             delete this.searchParams.oneOfNameHash[id];
+            this.trigger('change');
         },
 
         addLinkOneOf: function (id, name) {
@@ -364,6 +366,7 @@ Espo.define('views/fields/link', 'views/fields/base', function (Dep) {
                 this.searchData.oneOfIdList.push(id);
                 this.searchData.oneOfNameHash[id] = name;
                 this.addLinkOneOfHtml(id, name);
+                this.trigger('change');
             }
         },
 

--- a/client/src/views/fields/varchar.js
+++ b/client/src/views/fields/varchar.js
@@ -51,6 +51,7 @@ Espo.define('views/fields/varchar', 'views/fields/base', function (Dep) {
             } else {
                 this.$el.find('input.main-element').removeClass('hidden');
             }
+            this.trigger('change');
         },
 
         afterRender: function () {

--- a/client/src/views/record/search.js
+++ b/client/src/views/record/search.js
@@ -165,6 +165,7 @@ Espo.define('views/record/search', 'view', function (Dep) {
                     view.populateDefaults();
                     this.fetch();
                     this.updateSearch();
+                    this.updateCollection();
                 }.bind(this));
                 this.updateAddFilterButton();
                 this.handleLeftDropdownVisibility();
@@ -188,6 +189,7 @@ Espo.define('views/record/search', 'view', function (Dep) {
 
                 this.fetch();
                 this.updateSearch();
+                this.updateCollection();
 
                 this.manageLabels();
                 this.handleLeftDropdownVisibility();
@@ -606,6 +608,11 @@ Espo.define('views/record/search', 'view', function (Dep) {
                 if (rendered && !noRender) {
                     view.render();
                 }
+                this.listenTo(view, 'change', _.throttle(function () {
+                    this.fetch();
+                    this.updateSearch();
+                    this.updateCollection();
+                }, 450));
             }.bind(this));
         },
 


### PR DESCRIPTION
Automatically refetches collection while adjusting filters in list views

Uses throttling of 450ms to avoid hammering the backend with too many requests.

There's probably one or two field types which I haven't checked are working. Most needed slight modifications to trigger a change event on property changes.

Also could do with some settings to disable this on a system / user basis.