### PR TITLE
Use 'contains' as default text & varchar filter option

### DIFF
--- a/client/src/views/fields/text.js
+++ b/client/src/views/fields/text.js
@@ -48,7 +48,7 @@ Espo.define('views/fields/text', 'views/fields/base', function (Dep) {
 
         rowsDefault: 4,
 
-        searchTypeList: ['startsWith', 'contains', 'equals', 'isEmpty', 'isNotEmpty'],
+        searchTypeList: ['contains', 'startsWith', 'equals', 'isEmpty', 'isNotEmpty'],
 
         events: {
             'click a[data-action="seeMoreText"]': function (e) {

--- a/client/src/views/fields/varchar.js
+++ b/client/src/views/fields/varchar.js
@@ -34,7 +34,7 @@ Espo.define('views/fields/varchar', 'views/fields/base', function (Dep) {
 
         searchTemplate: 'fields/varchar/search',
 
-        searchTypeList: ['startsWith', 'endsWith', 'contains', 'equals', 'like', 'isEmpty', 'isNotEmpty'],
+        searchTypeList: ['contains', 'startsWith', 'endsWith', 'equals', 'like', 'isEmpty', 'isNotEmpty'],
 
         setupSearch: function () {
             this.events = _.extend({


### PR DESCRIPTION
Contains is the broadest search option, so should really be the default from a user perspective.