### PR TITLE
PATCH: More date filter options

### DIFF
--- a/application/Espo/Core/SelectManagers/Base.php
+++ b/application/Espo/Core/SelectManagers/Base.php
@@ -825,6 +825,14 @@ class Base
                 $where['value'] = [$from, $to];
 
                 break;
+            case 'beforeXDays':
+                $where['type'] = 'before';
+                $number = strval(intval($item['value']));
+                $dt->modify('-'.$number.' day');
+                $dt->setTime(0, 0, 0);
+                $dt->setTimezone(new \DateTimeZone('UTC'));
+                $where['value'] = $dt->format($format);
+                break;
             case 'lastXDays':
                 $where['type'] = 'between';
 
@@ -860,6 +868,14 @@ class Base
 
                 $where['value'] = [$from, $to];
 
+                break;
+            case 'afterXDays':
+                $where['type'] = 'after';
+                $number = strval(intval($item['value']));
+                $dt->modify('+'.$number.' day');
+                $dt->setTime(0, 0, 0);
+                $dt->setTimezone(new \DateTimeZone('UTC'));
+                $where['value'] = $dt->format($format);
                 break;
             case 'on':
                 $where['type'] = 'between';
@@ -1022,6 +1038,12 @@ class Base
                         $attribute . '<=' => $dt1->format('Y-m-d'),
                     );
                     break;
+                case 'beforeXDays':
+                    $dt1 = new \DateTime();
+                    $number = strval(intval($item['value']));
+                    $dt1->modify('-'.$number.' day');
+                    $part[$item['field'] . '<'] = $dt1->format('Y-m-d');
+                    break;
                 case 'lastXDays':
                     $dt1 = new \DateTime();
                     $dt2 = clone $dt1;
@@ -1032,6 +1054,12 @@ class Base
                         $attribute . '>=' => $dt2->format('Y-m-d'),
                         $attribute . '<=' => $dt1->format('Y-m-d'),
                     );
+                    break;
+                case 'afterXDays':
+                    $dt1 = new \DateTime();
+                    $number = strval(intval($item['value']));
+                    $dt1->modify('+'.$number.' day');
+                    $part[$item['field'] . '>'] = $dt1->format('Y-m-d');
                     break;
                 case 'nextXDays':
                     $dt1 = new \DateTime();

--- a/application/Espo/Resources/i18n/en_US/Global.json
+++ b/application/Espo/Resources/i18n/en_US/Global.json
@@ -479,7 +479,9 @@
             "currentYear": "Current Year",
             "lastYear": "Last Year",
             "lastSevenDays": "Last 7 Days",
+            "beforeXDays": "Before the last X Days",
             "lastXDays": "Last X Days",
+            "afterXDays": "After the next X Days",
             "nextXDays": "Next X Days",
             "ever": "Ever",
             "isEmpty": "Is Empty"

--- a/client/src/views/fields/date.js
+++ b/client/src/views/fields/date.js
@@ -42,7 +42,7 @@ Espo.define('views/fields/date', 'views/fields/base', function (Dep) {
 
         validations: ['required', 'date', 'after', 'before'],
 
-        searchTypeList: ['lastSevenDays', 'ever', 'isEmpty', 'currentMonth', 'lastMonth', 'currentQuarter', 'lastQuarter', 'currentYear', 'lastYear', 'today', 'past', 'future', 'lastXDays', 'nextXDays', 'on', 'after', 'before', 'between'],
+        searchTypeOptions: ['lastSevenDays', 'ever', 'isEmpty', 'currentMonth', 'lastMonth', 'currentQuarter', 'lastQuarter', 'currentYear', 'lastYear', 'today', 'past', 'future', 'beforeXDays', 'lastXDays', 'nextXDays', 'afterXDays', 'on', 'after', 'before', 'between'],
 
         setup: function () {
             Dep.prototype.setup.call(this);
@@ -187,7 +187,7 @@ Espo.define('views/fields/date', 'views/fields/base', function (Dep) {
 
             if (~['on', 'notOn', 'after', 'before'].indexOf(type)) {
                 this.$el.find('div.primary').removeClass('hidden');
-            } else if (~['lastXDays', 'nextXDays'].indexOf(type)) {
+            } else if (~['beforeXDays', 'lastXDays', 'nextXDays', 'afterXDays'].indexOf(type)) {
                 this.$el.find('div.additional-number').removeClass('hidden');
             } else if (type == 'between') {
                 this.$el.find('div.primary').removeClass('hidden');
@@ -229,7 +229,7 @@ Espo.define('views/fields/date', 'views/fields/base', function (Dep) {
                     dateValue: value,
                     dateValueTo: valueTo
                 };
-            } else if (~['lastXDays', 'nextXDays'].indexOf(type)) {
+            } else if (~['beforeXDays', 'lastXDays', 'nextXDays', 'afterXDays'].indexOf(type)) {
                 var number = this.$el.find('[name="' + this.name + '-number"]').val();
                 data = {
                     type: type,

--- a/client/src/views/fields/datetime.js
+++ b/client/src/views/fields/datetime.js
@@ -36,7 +36,7 @@ Espo.define('views/fields/datetime', 'views/fields/date', function (Dep) {
 
         validations: ['required', 'datetime', 'after', 'before'],
 
-        searchTypeList: ['lastSevenDays', 'ever', 'isEmpty', 'currentMonth', 'lastMonth', 'currentQuarter', 'lastQuarter', 'currentYear', 'lastYear', 'today', 'past', 'future', 'lastXDays', 'nextXDays', 'on', 'after', 'before', 'between'],
+        searchTypeOptions: ['lastSevenDays', 'ever', 'isEmpty', 'currentMonth', 'lastMonth', 'currentQuarter', 'lastQuarter', 'currentYear', 'lastYear', 'today', 'past', 'future', 'beforeXDays', 'lastXDays', 'nextXDays', 'afterXDays', 'on', 'after', 'before', 'between'],
 
         timeFormatMap: {
             'HH:mm': 'H:i',


### PR DESCRIPTION
'Before X days', though clumsily written means "At least X days in the past"

likewise with 'After X Days' = "At least X days into the future"

This field may need a refactor as there's other possible options still not covered and the list is huge.