### PR TITLE
Duplicate record checker in create mode

### DIFF
--- a/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Account.json
+++ b/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Account.json
@@ -2,6 +2,7 @@
     "fields": {
         "name": {
             "type": "varchar",
+            "view": "Fields.AccountName",
             "required": true,
             "trim": true
         },

--- a/application/Espo/Services/Record.php
+++ b/application/Espo/Services/Record.php
@@ -1228,13 +1228,26 @@ class Record extends \Espo\Core\Services\Base
                 $where['id!='] = $entity->id;
             }
             $duplicateList = $this->getRepository()->where($where)->find();
+            $extraDuplicatelist = [];
+            if ($this->entityType == 'Lead') {
+                $extraDuplicateList = $this->getEntityManager()->getRepository('Contact')->where($where)->find();
+            } else if ($this->entityType == 'Contact') {
+                $extraDuplicateList = $this->getEntityManager()->getRepository('Lead')->where($where)->find();
+            }
+            $result = array();
             if (count($duplicateList)) {
-                $result = array();
                 foreach ($duplicateList as $e) {
                     $result[$e->id] = $e->getValues();
+                    $result[$e->id]['entityType'] = $this->entityType;
                 }
-                return $result;
             }
+            if (count($extraDuplicateList)) {
+                foreach ($extraDuplicateList as $e) {
+                    $result[$e->id] = $e->getValues();
+                    $result[$e->id]['entityType'] = $this->entityType == 'Lead' ? 'Contact' : 'Lead';
+                }
+            }
+            return $result;
         }
         return false;
     }

--- a/client/res/templates/fields/person-name/detail.tpl
+++ b/client/res/templates/fields/person-name/detail.tpl
@@ -1,1 +1,1 @@
-{{translateOption salutationValue field='salutationName' scope=scope}} {{firstValue}} {{lastValue}}
+{{translateOption salutationValue field='salutationName' scope=scope}} {{nameValue}}

--- a/client/res/templates/fields/person-name/edit.tpl
+++ b/client/res/templates/fields/person-name/edit.tpl
@@ -1,13 +1,20 @@
 <div class="row">
     <div class="col-sm-3 col-xs-3">
         <select name="salutation{{ucName}}" class="form-control">
+            <option value="" disabled selected hidden>Title</option>
             {{options salutationOptions salutationValue field='salutationName' scope=scope}}
         </select>
     </div>
+{{#ifAttrNotEmpty model 'deleted'}}
     <div class="col-sm-4 col-xs-4">
         <input type="text" class="form-control" name="first{{ucName}}" value="{{firstValue}}" placeholder="{{translate 'First Name'}}">
     </div>
     <div class="col-sm-5 col-xs-5">
         <input type="text" class="form-control" name="last{{ucName}}" value="{{lastValue}}" placeholder="{{translate 'Last Name'}}">
     </div>
+{{else}}
+    <div class="col-sm-9 col-xs-9">
+        <input type="text" class="form-control" name="person{{ucName}}" value="{{nameValue}}" placeholder="Full Name">
+    </div>
+{{/ifAttrNotEmpty}}
 </div>

--- a/client/res/templates/modals/duplicate.tpl
+++ b/client/res/templates/modals/duplicate.tpl
@@ -1,13 +1,21 @@
 <h4>{{translate 'duplicate' category="messages"}}</h4>
 
-<div style="margin-top: 20px;">
-    <table class="table">
-    {{#each duplicates}}
-        <tr>
-            <td>
-                <a href="#{{../scope}}/view/{{id}}" target="_BLANK">{{name}}</a>
-            </td>
-        </tr>
-    {{/each}}
-    </table>
+<div class="list-container" style="margin-top: 20px;">
+    <div class="list-expanded">
+        <ul class="list-group">
+        {{#each duplicates}}
+            <li data-id="{{id}}" class="list-group-item list-row">
+                <div class="pull-right right cell" data-name="buttons">
+                    <span class="badge">{{entityType}}</span>
+                </div>
+                <div class="expanded-row">
+                    <span class="cell" data-name="name"><a href="#{{entityType}}/view/{{id}}" target="_BLANK">{{name}}</a>
+                    </span>
+                    <span class="cell" data-name="accountName">{{accountName}}</span>
+                    <span class="cell" data-name="email">{{emailAddress}}</span>
+                </div>
+            </li>
+        {{/each}}
+        </ul>
+    </div>
 </div>

--- a/client/src/views/email/fields/email-address-varchar.js
+++ b/client/src/views/email/fields/email-address-varchar.js
@@ -146,9 +146,9 @@ Espo.define('views/email/fields/email-address-varchar', ['views/fields/varchar',
                         return suggestion.name + ' &#60;' + suggestion.id + '&#62;';
                     },
                     transformResult: function (response) {
-                        var response = JSON.parse(response);
+                        var response = typeof response === 'string' ? JSON.parse(response) : response;
                         var list = [];
-                        response.forEach(function(item) {
+                        response.list.forEach(function(item) {
                             list.push({
                                 id: item.emailAddress,
                                 name: item.entityName,

--- a/client/src/views/email/fields/email-address.js
+++ b/client/src/views/email/fields/email-address.js
@@ -46,9 +46,9 @@ Espo.define('views/email/fields/email-address', ['views/fields/base'], function 
                         return suggestion.name + ' &#60;' + suggestion.id + '&#62;';
                     },
                     transformResult: function (response) {
-                        var response = JSON.parse(response);
+                        var response = typeof response === 'string' ? JSON.parse(response) : response;
                         var list = [];
-                        response.forEach(function(item) {
+                        response.list.forEach(function(item) {
                             list.push({
                                 id: item.emailAddress,
                                 name: item.entityName,

--- a/client/src/views/fields/account-name.js
+++ b/client/src/views/fields/account-name.js
@@ -1,0 +1,132 @@
+/************************************************************************
+ * This file is part of EspoCRM.
+ *
+ * EspoCRM - Open Source CRM application.
+ * Copyright (C) 2014-2015 Yuri Kuznetsov, Taras Machyshyn, Oleksiy Avramenko
+ * Website: http://www.espocrm.com
+ *
+ * EspoCRM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EspoCRM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EspoCRM. If not, see http://www.gnu.org/licenses/.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
+ ************************************************************************/
+
+Espo.define('views/fields/account-name', 'views/fields/varchar', function (Dep) {
+
+    return Dep.extend({
+
+        AUTOCOMPLETE_RESULT_MAX_COUNT: 7,
+
+        type: 'accountName',
+
+        generateDuplicateRow: function(item) {
+            let html = '<div class="autocomplete-duplicate-container">';
+            html += '<span style="float: left; margin-right: 10px;" class="glyphicon glyphicon-home"></span>';
+            let address = typeof item.billingAddressCity == 'string' ? (', ' + item.billingAddressCity) : '';
+            if (typeof item.billingAddressCity == 'string') {
+                address = typeof item.billingAddressPostalCode == 'string' ? address + ', ' + item.billingAddressPostalCode : address;
+            }
+            html += '<span style="width: 65%; overflow: hidden; text-overflow: ellipsis"><span style="border-bottom: 1px dotted;">' + item.name + '</span>' + address + '</span>';
+            html += '<span style="float: right; color: #999">' + item.entityType + '</span></div><!-- autocomplete-duplicate-container -->';
+            return html;
+        },
+
+        afterRender: function () {
+            Dep.prototype.afterRender.call(this);
+
+            if (this.mode == 'edit' && typeof this.model.id == 'undefined') {
+                this.$element.autocomplete({
+                    serviceUrl: [
+                        'Account?sortBy=name&maxCount=' + this.AUTOCOMPLETE_RESULT_MAX_COUNT
+                    ],
+                    paramName: 'q',
+                    minChars: 3,
+                    autoSelectFirst: false,
+                    transformResult: function (response) {
+                        var list = [];
+                        response.list.forEach(function(item) {
+                            item.entityType = 'Company';
+                            list.push({
+                                item: item,
+                                data: item.id,
+                                value: this.generateDuplicateRow(item)
+                            });
+                        }, this);
+                        return {
+                            suggestions: list
+                        };
+                    }.bind(this),
+                    onSelect: function (s) {
+                        if (this.model.urlRoot == 'Lead') {
+
+                            this.notify('Creating Contact instead...');
+
+                            var viewName = this.getMetadata().get('clientDefs.Contact.modalViews.edit') || 'views/modals/edit';
+
+                            //FIXME HACK
+                            let model = {
+                                id: s.item.id,
+                                name: 'Account',
+                                _name: s.item.name,
+                                get: function(q) {
+                                    return this["_"+q];
+                                }
+                            };
+
+                            let attributes = {
+                                accountId: s.item.id,
+                                accountName: s.item.name,
+                                addressCity: s.item.addressCity,
+                                addressPostalCode: s.item.addressPostalCode,
+                                addressState: s.item.addressState,
+                                addressStreet: s.item.addressStreet
+                            };
+
+                            $('.modal-header > a')[0].click();
+
+                            this.createView('quickCreate', viewName, {
+                                scope: 'Contact',
+                                relate: {
+                                    model: model,
+                                    link: 'accounts',
+                                },
+                                attributes: attributes,
+                            }, function (view) {
+                                view.render();
+                                view.notify(false);
+                            }.bind(this));
+                        } else {
+                            this.$element.val('');
+                            $('.modal-header > a')[0].click();
+                            window.location.href = this.getConfig().get('siteUrl') + '#Account/view/' + s.data;
+                        }
+                    }.bind(this)
+                });
+
+                this.once('render', function () {
+                    this.$element.autocomplete('dispose');
+                }, this);
+
+                this.once('remove', function () {
+                    this.$element.autocomplete('dispose');
+                }, this);
+            }
+        }
+    });
+});
+

--- a/client/src/views/fields/email.js
+++ b/client/src/views/fields/email.js
@@ -216,9 +216,9 @@ Espo.define('views/fields/email', 'views/fields/varchar', function (Dep) {
                         return suggestion.name + ' &#60;' + suggestion.id + '&#62;';
                     },
                     transformResult: function (response) {
-                        var response = JSON.parse(response);
+                        var response = typeof response === 'string' ? JSON.parse(response) : response;
                         var list = [];
-                        response.forEach(function(item) {
+                        response.list.forEach(function(item) {
                             list.push({
                                 id: item.emailAddress,
                                 name: item.entityName,

--- a/client/src/views/fields/link-multiple.js
+++ b/client/src/views/fields/link-multiple.js
@@ -195,7 +195,7 @@ Espo.define('views/fields/link-multiple', 'views/fields/base', function (Dep) {
                             return suggestion.name;
                         },
                         transformResult: function (response) {
-                            var response = JSON.parse(response);
+                            var response = typeof response === 'string' ? JSON.parse(response) : response;
                             var list = [];
                             response.list.forEach(function(item) {
                                 list.push({

--- a/client/src/views/fields/link-parent.js
+++ b/client/src/views/fields/link-parent.js
@@ -225,7 +225,7 @@ Espo.define('views/fields/link-parent', 'views/fields/base', function (Dep) {
                             return suggestion.name;
                         },
                         transformResult: function (response) {
-                            var response = JSON.parse(response);
+                            var response = typeof response === 'string' ? JSON.parse(response) : response;
                             var list = [];
                             response.list.forEach(function(item) {
                                 list.push({

--- a/client/src/views/fields/link.js
+++ b/client/src/views/fields/link.js
@@ -244,7 +244,7 @@ Espo.define('views/fields/link', 'views/fields/base', function (Dep) {
                             return suggestion.name;
                         },
                         transformResult: function (response) {
-                            var response = JSON.parse(response);
+                            var response = typeof response === 'string' ? JSON.parse(response) : response;
                             var list = [];
                             response.list.forEach(function(item) {
                                 list.push({
@@ -288,7 +288,7 @@ Espo.define('views/fields/link', 'views/fields/base', function (Dep) {
                                 return suggestion.name;
                             },
                             transformResult: function (response) {
-                                var response = JSON.parse(response);
+                                var response = typeof response === 'string' ? JSON.parse(response) : response;
                                 var list = [];
                                 response.list.forEach(function(item) {
                                     list.push({

--- a/client/src/views/fields/user.js
+++ b/client/src/views/fields/user.js
@@ -100,7 +100,7 @@ Espo.define('views/fields/user', 'views/fields/link', function (Dep) {
                         return suggestion.name;
                     },
                     transformResult: function (response) {
-                        var response = JSON.parse(response);
+                        var response = typeof response === 'string' ? JSON.parse(response) : response;
                         var list = [];
                         response.list.forEach(function(item) {
                             list.push({

--- a/client/src/views/modals/duplicate.js
+++ b/client/src/views/modals/duplicate.js
@@ -47,7 +47,7 @@ Espo.define('views/modals/duplicate', 'views/modal', function (Dep) {
             this.buttonList = [
                 {
                     name: 'save',
-                    label: 'Save',
+                    label: 'Create Anyway',
                     style: 'danger',
                     onClick: function (dialog) {
                         this.trigger('save');


### PR DESCRIPTION
This isn't completely bug free I think but it's a useful feature. Maybe you would like to take something like this on?

The benefit is the user's get notification of duplicates whilst entering the details, not afterwards.

When entering a new Lead, Contact or Company's name,  an ajax request is made and returns possible matches. If a match is clicked, user is taken to that record instead.

In the case of creating a new lead with accountName == an existing Account, create a  Contact instead.

In the image you see a company name matching existing records. In this case a Contact would be preferable rather than a lead.

In order to use the existing suggestion code, the dual first + last name input fields are replaced with one field while in create mode. First and Last are split from the concatenated name when the record is saved.

Also -jQuery.autocomplete modified so that it supports multiple simultaneous request. This is so you can query Leads + Contacts and wait on both results before presenting to the user.

Screen shot of how it looks for us:
![2016-11-18_563x547_escrotum](https://cloud.githubusercontent.com/assets/7381617/20450803/2d38fff0-adeb-11e6-9051-b55b687e6d9d.png)

