### PR TITLE
Compose from email address not sorted by primary

### DIFF
--- a/client/src/views/email/fields/compose-from-address.js
+++ b/client/src/views/email/fields/compose-from-address.js
@@ -46,10 +46,14 @@ Espo.define('views/email/fields/compose-from-address', 'views/fields/base', func
                 this.list.push(this.getUser().get('emailAddress'));
             }*/
 
+            this.list.push(this.getUser().get('emailAddress'));
+
             var emailAddressList = this.getUser().get('emailAddressList') || [];
             emailAddressList.forEach(function (item) {
                 this.list.push(item);
             }, this);
+
+            this.list = _.uniq(this.list);
 
             if (this.getConfig().get('outboundEmailIsShared') && this.getConfig().get('outboundEmailFromAddress')) {
                 var address = this.getConfig().get('outboundEmailFromAddress');


### PR DESCRIPTION
The compose email dialog uses the user's email address with the lowest id (first in table), rather than the primary one.

This fixes it but may not be they way you'd do it.