### PR TITLE
Hide converted leads from Global search

### DIFF
--- a/application/Espo/Services/GlobalSearch.php
+++ b/application/Espo/Services/GlobalSearch.php
@@ -88,6 +88,13 @@ class GlobalSearch extends \Espo\Core\Services\Base
             $selectManager = $this->getSelectManagerFactory()->create($entityType);
             $selectManager->manageAccess($params);
             $selectManager->manageTextFilter($query, $params);
+            if ($entityType === 'Lead') {
+              $params['whereClause'][0][] = array(
+                "AND" => array(
+                  "status!=" => "Converted"
+                )
+              );
+            }
 
             $sql = $this->getEntityManager()->getQuery()->createSelectQuery($entityType, $params);
 


### PR DESCRIPTION
I don't think users really need to have both the Contact & the converted Lead record in the Global Search results.