### PR TITLE
Role Inactive support for Contact

### DIFF
--- a/application/Espo/Modules/Crm/Repositories/Contact.php
+++ b/application/Espo/Modules/Crm/Repositories/Contact.php
@@ -41,9 +41,13 @@ class Contact extends \Espo\Core\ORM\Repositories\RDB
             $params['customJoin'] = '';
         }
 
+        //FIXME This avoids regular requests for Contacts without linked Account properties to work. Must be another solution though?
+        if (!in_array('account', $params['leftJoins'])) {
+            $params['leftJoins'][] = 'account';
+        }
         $params['customJoin'] .= "
             LEFT JOIN `account_contact` AS accountContact
-            ON accountContact.contact_id = contact.id AND accountContact.account_id = contact.account_id AND accountContact.deleted = 0
+            ON accountContact.contact_id = contact.id AND accountContact.account_id = account.id AND accountContact.active = 1 AND accountContact.deleted = 0
         ";
     }
 

--- a/application/Espo/Modules/Crm/Resources/i18n/en_US/Contact.json
+++ b/application/Espo/Modules/Crm/Resources/i18n/en_US/Contact.json
@@ -4,6 +4,7 @@
         "emailAddress": "Email",
         "title": "Title",
         "account": "Account",
+        "accountActive": "Active Role",
         "accounts": "Accounts",
         "phoneNumber": "Phone",
         "accountType": "Account Type",

--- a/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Account.json
+++ b/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Account.json
@@ -88,6 +88,11 @@
             "notStorable": true,
             "disabled": true
         },
+        "contactActive": {
+            "type": "bool",
+            "notStorable": true,
+            "disabled": true
+        },
         "billingAddress": {
             "type": "address"
         },

--- a/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Contact.json
+++ b/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Contact.json
@@ -20,14 +20,28 @@
         },
         "accountId": {
             "where": {
-                "=": "contact.id IN (SELECT contact_id FROM account_contact WHERE deleted = 0 AND account_id = {value})",
-                "<>": "contact.id IN (SELECT contact_id FROM account_contact WHERE deleted = 0 AND account_id <> {value})",
-                "IN": "contact.id IN (SELECT contact_id FROM account_contact WHERE deleted = 0 AND account_id IN {value})",
-                "NOT IN": "contact.id NOT IN (SELECT contact_id FROM account_contact WHERE deleted = 0 AND account_id IN {value})",
+                "=": "contact.id IN (SELECT contact_id FROM account_contact WHERE deleted = 0 AND active = {accountActive} AND account_id = {value})",
+                "<>": "contact.id IN (SELECT contact_id FROM account_contact WHERE deleted = 0 AND active = {accountActive} AND account_id <> {value})",
+                "IN": "contact.id IN (SELECT contact_id FROM account_contact WHERE deleted = 0 AND active = {accountActive} AND account_id IN {value})",
+                "NOT IN": "contact.id NOT IN (SELECT contact_id FROM account_contact WHERE deleted = 0 AND active = {accountActive} AND account_id IN {value})",
                 "IS NULL": "contact.account_id IS NULL",
                 "IS NOT NULL": "contact.account_id IS NOT NULL"
             },
             "disabled": true
+        },
+        "accountActive": {
+            "disabled": true,
+            "type": "bool",
+            "notStorable": true,
+            "select": "accountContact.active",
+            "orderBy": "accountContact.active {direction}",
+            "where": {
+                "=": {
+                    "leftJoins": ["accounts"],
+                    "sql": "accountsMiddle.active = {value}",
+                    "distinct": true
+                }
+            }
         },
         "title": {
             "type": "varchar",
@@ -105,7 +119,8 @@
             "type": "linkMultiple",
             "view": "crm:views/contact/fields/accounts",
             "columns": {
-                "role": "contactRole"
+                "role": "contactRole",
+                "active": "contactActive"
             }
         },
         "accountRole": {
@@ -226,6 +241,10 @@
                 "role": {
                     "type": "varchar",
                     "len": 50
+                },
+                "active": {
+                    "type": "bool",
+                    "default": true
                 }
             },
             "layoutRelationshipsDisabled": true

--- a/application/Espo/Modules/Crm/Services/Account.php
+++ b/application/Espo/Modules/Crm/Services/Account.php
@@ -36,7 +36,8 @@ class Account extends \Espo\Services\Record
     protected $linkSelectParams = array(
         'contacts' => array(
             'additionalColumns' => array(
-                'role' => 'accountRole'
+                'role' => 'accountRole',
+                'active' => 'accountActive'
             )
         )
     );

--- a/application/Espo/ORM/DB/Mapper.php
+++ b/application/Espo/ORM/DB/Mapper.php
@@ -267,6 +267,10 @@ abstract class Mapper implements IMapper
 
                 $params['relationName'] = $relOpt['relationName'];
 
+                if ($entity->getEntityType() === 'Account' && $relationName === 'contacts') {
+                  $params['customJoin'] = $params['customJoin']." AND account_contact.active = 1";
+                }
+
                 $sql = $this->query->createSelectQuery($relEntity->getEntityType(), $params);
 
                 $resultArr = [];

--- a/application/Espo/ORM/DB/Query/Base.php
+++ b/application/Espo/ORM/DB/Query/Base.php
@@ -624,6 +624,15 @@ abstract class Base
     {
         $whereParts = array();
 
+        $accountActive = null;
+        if ($entity->getEntityType() === 'Contact') {
+            foreach ($whereClause as $field => $value) {
+                if ($field === 'accountId=') {
+                    $accountActive = true;
+                    break;
+                }
+            }
+        }
         foreach ($whereClause as $field => $value) {
 
             if (is_int($field)) {
@@ -717,6 +726,10 @@ abstract class Base
                             $params['distinct'] = true;
                         }
                         $whereParts[] = str_replace('{value}', $this->stringifyValue($value), $whereSqlPart);
+
+                        if (isset($accountActive)) {
+                          $whereParts[] = str_replace('{accountActive}', $this->pdo->quote($accountActive), array_pop($whereParts));
+                        }
                     } else {
                         if ($fieldDefs['type'] == IEntity::FOREIGN) {
                             $leftPart = '';

--- a/client/res/templates/fields/base/detail.tpl
+++ b/client/res/templates/fields/base/detail.tpl
@@ -1,1 +1,10 @@
-{{value}}
+{{#ifAttrNotEmpty model 'active'}}
+    {{#ifAttrEquals model 'active' false}}
+        <span style="text-decoration:line-through">{{value}}</span>
+    {{else}}
+        {{value}}
+    {{/ifAttrEquals}}
+{{else}}
+    {{value}}
+{{/ifAttrNotEmpty}}
+

--- a/client/res/templates/fields/link/list.tpl
+++ b/client/res/templates/fields/link/list.tpl
@@ -1,4 +1,14 @@
 {{#if idValue}}
-	<a href="#{{foreignScope}}/view/{{idValue}}" title="{{nameValue}}">{{nameValue}}</a>
+	<a href="#{{foreignScope}}/view/{{idValue}}" title="{{nameValue}}">
+{{#ifAttrNotEmpty model 'dept'}}
+{{#ifAttrNotEmpty model 'accountActive'}}
+{{nameValue}}
+{{else}}
+<span style="text-decoration:line-through;color:#999">{{nameValue}}</span>
+{{/ifAttrNotEmpty}}
+{{else}}
+{{nameValue}}
+{{/ifAttrNotEmpty}}
+</a>
 {{/if}}
 

--- a/client/src/views/fields/link-multiple-with-role-active.js
+++ b/client/src/views/fields/link-multiple-with-role-active.js
@@ -1,0 +1,47 @@
+/************************************************************************
+ * This file is part of EspoCRM.
+ *
+ * EspoCRM - Open Source CRM application.
+ * Copyright (C) 2014-2015 Yuri Kuznetsov, Taras Machyshyn, Oleksiy Avramenko
+ * Website: http://www.espocrm.com
+ *
+ * EspoCRM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EspoCRM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EspoCRM. If not, see http://www.gnu.org/licenses/.
+ ************************************************************************/
+
+Espo.define('Views.Fields.LinkMultipleWithRoleActive', 'Views.Fields.LinkMultipleWithRole', function (Dep) {
+
+    return Dep.extend({
+
+        type: 'linkMultipleWithRoleActive',
+
+        getDetailLinkHtml: function (id, name) {
+            name = name || this.nameHash[id];
+
+            var role = (this.columns[id] || {})[this.columnName] || '';
+            var active = typeof this.columns[id] === 'undefined' || typeof this.columns[id].active === 'undefined' || this.columns[id].active;
+            var roleHtml = '';
+            if (role != '') {
+                roleHtml = '<span class="text-muted small"> &#187; ' + this.getLanguage().translateOption(role, this.roleField, this.roleFieldScope) + '</span>';
+            }
+            if (!active) {
+                return '<div>' + '<a href="#' + this.foreignScope + '/view/' + id + '"><span style="text-decoration:line-through;color:#999">' + name + '</span></a> ' + roleHtml + '</div>';
+            } else {
+                return '<div>' + '<a href="#' + this.foreignScope + '/view/' + id + '">' + name + '</a> ' + roleHtml + '</div>';
+            }
+        },
+
+    });
+});
+
+


### PR DESCRIPTION
Hi - I mentioned this in the forums a while ago.

http://forum.espocrm.com/forum/developer-help/5919-inactive-role-feature-for-contact-account-relationship

It's a useful way of tracking people who have left an account.

Modifies the account_contact table to include a boolean field `active`, and then modifies default behaviour so that contacts with an inactive role are not retrieved when being queried in relation to an account.

However I think it could be cleaner. Im not an expert in the internals of the ORM and the way I'm handling the `accountActive` field in Base.php is not great. Would welcome any suggestions and potential inclusion in core Espo.

There's also some strange behaviour where using the Reports feature, filtering using Account works, but not Accounts. This will be down to my addition of another join mentioned above.