### PR TITLE
Pinned notes

### DIFF
--- a/application/Espo/Resources/i18n/en_US/Note.json
+++ b/application/Espo/Resources/i18n/en_US/Note.json
@@ -2,6 +2,7 @@
     "fields": {
         "post": "Post",
         "attachments": "Attachments",
+        "isPinned": "Pinned to top",
         "targetType": "Target",
         "teams": "Teams",
         "users": "Users",

--- a/application/Espo/Resources/layouts/Note/detailSmall.json
+++ b/application/Espo/Resources/layouts/Note/detailSmall.json
@@ -8,7 +8,8 @@
                 }
             ],
             [
-                {"name":"attachments"}
+                {"name":"attachments"},
+                {"name":"isPinned"}
             ]
         ]
     }

--- a/application/Espo/Resources/metadata/entityDefs/Note.json
+++ b/application/Espo/Resources/metadata/entityDefs/Note.json
@@ -59,6 +59,11 @@
         "isInternal": {
             "type": "bool"
         },
+        "isPinned": {
+            "type": "bool",
+            "default": false,
+            "tooltipText": "Pinned notes appear at the top of the activity panel"
+        },
         "createdAt": {
             "type": "datetime",
             "readOnly": true

--- a/application/Espo/Services/Stream.php
+++ b/application/Espo/Services/Stream.php
@@ -638,8 +638,10 @@ class Stream extends \Espo\Core\Services\Base
             'whereClause' => $where,
             'offset' => $params['offset'],
             'limit' => $params['maxSize'],
-            'orderBy' => 'number',
-            'order' => 'DESC'
+            'orderBy' => [
+                ['isPinned', 'desc'],
+                ['number', 'desc']
+            ]
         ));
 
 

--- a/client/res/templates/stream/notes/post.tpl
+++ b/client/res/templates/stream/notes/post.tpl
@@ -3,6 +3,10 @@
     {{#unless noEdit}}
     <div class="pull-right right-container">
     {{{right}}}
+    {{#if isPinned}}
+        <span class="label label-info">Pinned</span>
+        <span class="glyphicon glyphicon-pushpin danger"></span>
+    {{/if}}
     </div>
     {{/unless}}
 
@@ -19,6 +23,7 @@
         <div class="stream-head-text-container">
             <span class="text-muted message">{{{message}}}</span>
         </div>
+
     </div>
 
     {{#if showPost}}

--- a/client/src/views/stream/notes/post.js
+++ b/client/src/views/stream/notes/post.js
@@ -38,11 +38,14 @@ Espo.define('views/stream/notes/post', 'views/stream/note', function (Dep) {
 
         isRemovable: true,
 
+        isPinned: false,
+
         data: function () {
             var data = Dep.prototype.data.call(this);
             data.showAttachments = !!(this.model.get('attachmentsIds') || []).length;
             data.showPost = !!this.model.get('post');
             data.isInternal = this.isInternal;
+            data.isPinned = this.isPinned;
             return data;
         },
 
@@ -52,6 +55,7 @@ Espo.define('views/stream/notes/post', 'views/stream/note', function (Dep) {
             this.createField('attachments', 'attachmentMultiple', {}, 'views/stream/fields/attachment-multiple');
 
             this.isInternal = this.model.get('isInternal');
+            this.isPinned = this.model.get('isPinned');
 
             if (!this.model.get('post') && this.model.get('parentId')) {
                 this.messageName = 'attach';
@@ -62,6 +66,10 @@ Espo.define('views/stream/notes/post', 'views/stream/note', function (Dep) {
 
             this.listenTo(this.model, 'change', function () {
                 if (this.model.hasChanged('post') || this.model.hasChanged('attachmentsIds')) {
+                    this.reRender();
+                }
+                if (this.model.hasChanged('isPinned')) {
+                    this.isPinned = this.model.get('isPinned');
                     this.reRender();
                 }
             }, this);

--- a/client/src/views/stream/panel.js
+++ b/client/src/views/stream/panel.js
@@ -226,6 +226,10 @@ Espo.define('views/stream/panel', ['views/record/panels/relationship', 'lib!Text
                 collection.fetch();
             }
 
+            this.listenTo(collection, 'change', function() {
+                collection.fetch();
+            });
+
             var assignmentPermission = this.getAcl().get('assignmentPermission');
 
             var buildUserListUrl = function (term) {


### PR DESCRIPTION
Method for users to pin a post to the top of the stream panel.

However - right now notes pinned to child entities appear pinned in the super parent entity too. This is due to fetching child notes in the same query. It would be nice to manage this better.

If you have a suggested better way to achieve this let me know.

![screen shot 2017-04-04 at 13 03 31](https://cloud.githubusercontent.com/assets/7381617/24655689/20ac7dae-1937-11e7-8670-2c809e338f91.png)

![screen shot 2017-04-04 at 13 03 55](https://cloud.githubusercontent.com/assets/7381617/24655701/34006c62-1937-11e7-91a5-351f02e6c1aa.png)
