### PR TITLE
Excel exports

### DIFF
--- a/application/Espo/Core/Utils/Layout.php
+++ b/application/Espo/Core/Utils/Layout.php
@@ -107,6 +107,24 @@ class Layout
             $defaultPath = $this->params['defaultsPath'];
             $fileFullPath =  Util::concatPath(Util::concatPath($defaultPath, 'layouts'), $name . '.json' );
 
+            if ($name === 'exportFields') {
+
+                $listLayoutPath = Util::concatPath($this->getLayoutPath($scope, true), 'list' . '.json');
+                if (!file_exists($listLayoutPath)) {
+                    $listLayoutPath = Util::concatPath($this->getLayoutPath($scope), 'list' . '.json');
+                }
+                if (!file_exists($listLayoutPath)) {
+                    $listLayoutPath =  Util::concatPath(Util::concatPath($defaultPath, 'layouts'), $name . '.json' );
+                }
+
+                $listFields = json_decode($this->getFileManager()->getContents($listLayoutPath));
+                $defaultExportFields = array_map(function($e) {
+                    return $e->name;
+                }, $listFields);
+
+                return json_encode($defaultExportFields);
+            }
+
             if (!file_exists($fileFullPath)) {
                 return false;
             }

--- a/application/Espo/Resources/i18n/en_US/Admin.json
+++ b/application/Espo/Resources/i18n/en_US/Admin.json
@@ -63,6 +63,7 @@
         "listSmall": "List (Small)",
         "detailSmall": "Detail (Small)",
         "filters": "Search Filters",
+        "exportFields": "Export Fields",
         "massUpdate": "Mass Update",
         "relationships": "Relationship Panels",
         "sidePanelsDetail": "Side Panels (Detail)",

--- a/application/Espo/Services/Record.php
+++ b/application/Espo/Services/Record.php
@@ -1406,7 +1406,7 @@ class Record extends \Espo\Core\Services\Base
         return $this->doExcelOutput($arr, $exportFields, $this->entityType);
     }
 
-    protected function doExcelOutput($arr, $exportFields, $entityType) {
+    protected function doExcelOutput($arr, $exportFields, $entityType, $reportName = NULL) {
         $objPHPExcel = new \PHPExcel();
         $sheet = $objPHPExcel->setActiveSheetIndex(0);
         $sheet->setTitle($this->getLanguage()->translate($entityType, 'scopeNamesPlural'));
@@ -1419,16 +1419,30 @@ class Record extends \Espo\Core\Services\Base
         // Title
         $titleStyle = array(
             'alignment' => array(
-                'vertical' => \PHPExcel_Style_Alignment::VERTICAL_TOP
+                'vertical' => \PHPExcel_Style_Alignment::VERTICAL_CENTER
             ),
             'font'  => array(
                 'bold'  => true,
                 'size'  => 18
             )
         );
-        $sheet->setCellValue("B1", $this->getLanguage()->translate($entityType, 'scopeNamesPlural') . " export");
+        $dateStyle = array(
+            'alignment' => array(
+                'vertical' => \PHPExcel_Style_Alignment::VERTICAL_CENTER
+            ),
+            'font'  => array(
+                'size'  => 16
+            )
+        );
+        if ($reportName) {
+            $sheet->setCellValue("B1", $this->getLanguage()->translate($entityType, 'scopeNamesPlural') . " report: '$reportName'");
+        } else {
+            $sheet->setCellValue("B1", $this->getLanguage()->translate($entityType, 'scopeNamesPlural') . " export");
+        }
+        $sheet->setCellValue("C1", 'Exported: '.date("D M j G:i:s Y"));
         $sheet->getRowDimension('1')->setRowHeight(40);
         $sheet->getStyle("B1")->applyFromArray($titleStyle);
+        $sheet->getStyle("C1")->applyFromArray($dateStyle);
 
         \PHPExcel_Shared_Font::setTrueTypeFontPath('/usr/share/fonts/truetype/msttcorefonts/');
         \PHPExcel_Shared_Font::setAutoSizeMethod(\PHPExcel_Shared_Font::AUTOSIZE_METHOD_EXACT);
@@ -1481,7 +1495,9 @@ class Record extends \Espo\Core\Services\Base
                     if ($entityType == 'Contact') {
                         $sheet->setCellValue("$col$rowNumber", $row['name']);
                     } else {
-                        if ($row['firstName']) {
+                        if ($row['name']) {
+                            $sheet->setCellValue("$col$rowNumber", $row['name']);
+                        } else if ($row['firstName']) {
                             $personName = $row['firstName'];
                             if ($row['lastName']) {
                                 $personName .= " ".$row['lastName'];

--- a/application/Espo/Services/Record.php
+++ b/application/Espo/Services/Record.php
@@ -53,7 +53,9 @@ class Record extends \Espo\Core\Services\Base
         'fileManager',
         'selectManagerFactory',
         'preferences',
-        'fileStorageManager'
+        'fileStorageManager',
+        'layout',
+        'language'
     );
 
     protected $getEntityBeforeUpdate = false;
@@ -148,6 +150,16 @@ class Record extends \Espo\Core\Services\Base
     protected function getPreferences()
     {
         return $this->injections['preferences'];
+    }
+
+    protected function getLayout()
+    {
+        return $this->injections['layout'];
+    }
+
+    protected function getLanguage()
+    {
+        return $this->injections['language'];
     }
 
     protected function getMetadata()
@@ -345,6 +357,13 @@ class Record extends \Espo\Core\Services\Base
 
     public function loadAdditionalFieldsForExport(Entity $entity)
     {
+        $this->loadLinkFields($entity);
+        $this->loadLinkMultipleFields($entity);
+        $this->loadParentNameFields($entity);
+        $this->loadIsFollowed($entity);
+        $this->loadEmailAddressField($entity);
+        $this->loadPhoneNumberField($entity);
+        $this->loadNotJoinedLinkFields($entity);
     }
 
     protected function loadEmailAddressField(Entity $entity)
@@ -1259,7 +1278,7 @@ class Record extends \Espo\Core\Services\Base
         }
     }
 
-    public function export(array $params)
+    public function prepareExport(array $params)
     {
         $selectManager = $this->getSelectManager($this->getEntityType());
         if (array_key_exists('ids', $params)) {
@@ -1287,10 +1306,8 @@ class Record extends \Espo\Core\Services\Base
             throw new BadRequest();
         }
 
-        $orderBy = $this->getMetadata()->get(['entityDefs', $this->getEntityType(), 'collection', 'sortBy']);
-        $desc = !$this->getMetadata()->get(['entityDefs', $this->getEntityType(), 'collection', 'asc']);
-        if ($orderBy) {
-            $selectManager->applyOrder($orderBy, $desc, $selectParams);
+        if ($params['orderBy']) {
+            $selectManager->applyOrder($params['orderBy'], $params['order'] == 'DESC', $selectParams);
         }
 
         $collection = $this->getRepository()->find($selectParams);
@@ -1312,27 +1329,34 @@ class Record extends \Espo\Core\Services\Base
         }
 
         $attributeList = null;
-        if (array_key_exists('attributeList', $params)) {
-            $attributeList = [];
-            $entity = $this->getEntityManager()->getEntity($this->getEntityType());
-            foreach ($params['attributeList'] as $attribute) {
-                if (in_array($attribute, $attributeListToSkip)) {
-                    continue;
-                }
-                if ($this->checkAttributeIsAllowedForExport($entity, $attribute)) {
-                    $attributeList[] = $attribute;
-                }
-            }
-        }
+        // not allowing custom lists
+        /* if (array_key_exists('attributeList', $params)) { */
+        /*     $attributeList = []; */
+        /*     $entity = $this->getEntityManager()->getEntity($this->getEntityType()); */
+        /*     foreach ($params['attributeList'] as $attribute) { */
+        /*         if (in_array($attribute, $attributeListToSkip)) { */
+        /*             continue; */
+        /*         } */
+        /*         if ($this->checkAttributeIsAllowedForExport($entity, $attribute)) { */
+        /*             $attributeList[] = $attribute; */
+        /*         } */
+        /*     } */
+        /* } */
 
         foreach ($collection as $entity) {
+            $this->loadAdditionalFieldsForExport($entity);
             if (is_null($attributeList)) {
                 $attributeList = [];
                 foreach ($entity->getAttributes() as $attribute => $defs) {
                     if (in_array($attribute, $attributeListToSkip)) {
                         continue;
                     }
-                    if ($this->checkAttributeIsAllowedForExport($entity, $attribute)) {
+
+                    if ($attribute == 'accountRole' || $attribute == 'title') {
+                        $attributeList[] = 'title';
+                    } else if ($defs['type'] == 'accountRole') {
+                        $attributeList[] = 'title';
+                    } else if (in_array($defs['type'], ['email', 'phone'])) {
                         $attributeList[] = $attribute;
                     }
                 }
@@ -1341,7 +1365,6 @@ class Record extends \Espo\Core\Services\Base
                 }
             }
 
-            $this->loadAdditionalFieldsForExport($entity);
             $row = array();
             foreach ($attributeList as $attribute) {
                 $value = $this->getAttributeFromEntityForExport($entity, $attribute);
@@ -1349,32 +1372,250 @@ class Record extends \Espo\Core\Services\Base
             }
             $arr[] = $row;
         }
+        return $arr;
+    }
 
-        $delimiter = $this->getPreferences()->get('exportDelimiter');
-        if (empty($delimiter)) {
-            $delimiter = $this->getConfig()->get('exportDelimiter', ';');
+    public function export(array $params)
+    {
+        $collectionParams = $this->getMetadata()->get('entityDefs.' . $this->entityType . '.collection', array());
+
+        $params['orderBy']  = $collectionParams['sortBy'];
+        $params['order']  = $collectionParams['asc'] ? 'ASC' : 'DESC';
+
+        $arr = $this->prepareExport($params);
+
+        $layoutFields = json_decode($this->getLayout()->get($this->entityType, 'exportFields'));
+
+        $fieldDefs = $this->getMetadata()->get('entityDefs.' . $this->entityType . '.fields', array());
+        $linkDefs = $this->getMetadata()->get('entityDefs.' . $this->entityType . '.links', array());
+
+        $exportFields = [];
+        // for passed field list as params
+        foreach ($layoutFields as $layoutField)  {
+            $label = $this->getLanguage()->translate($layoutField, 'fields', $this->entityType);
+            $def = [];
+            if (array_key_exists($layoutField, $linkDefs)) {
+                $def = $linkDefs[$layoutField];
+            } else if (array_key_exists($layoutField, $fieldDefs)) {
+                $def = $fieldDefs[$layoutField];
+            }
+            $def['label'] = $label;
+            $exportFields[$layoutField] = $def;
         }
 
-        $fp = fopen('php://temp', 'w');
-        fputcsv($fp, array_keys($arr[0]), $delimiter);
+        return $this->doExcelOutput($arr, $exportFields, $this->entityType);
+    }
+
+    protected function doExcelOutput($arr, $exportFields, $entityType) {
+        $objPHPExcel = new \PHPExcel();
+        $sheet = $objPHPExcel->setActiveSheetIndex(0);
+        $sheet->setTitle($this->getLanguage()->translate($entityType, 'scopeNamesPlural'));
+
+        $exportFields = array_merge([ 'id' => [
+            'label' => 'Id',
+            'type' => 'varchar'
+        ]], $exportFields);
+
+        // Title
+        $titleStyle = array(
+            'alignment' => array(
+                'vertical' => \PHPExcel_Style_Alignment::VERTICAL_TOP
+            ),
+            'font'  => array(
+                'bold'  => true,
+                'size'  => 18
+            )
+        );
+        $sheet->setCellValue("B1", $this->getLanguage()->translate($entityType, 'scopeNamesPlural') . " export");
+        $sheet->getRowDimension('1')->setRowHeight(40);
+        $sheet->getStyle("B1")->applyFromArray($titleStyle);
+
+        \PHPExcel_Shared_Font::setTrueTypeFontPath('/usr/share/fonts/truetype/msttcorefonts/');
+        \PHPExcel_Shared_Font::setAutoSizeMethod(\PHPExcel_Shared_Font::AUTOSIZE_METHOD_EXACT);
+
+        // Column Headers
+        $col = 'A';
+        $rowNumber = 2;
+        $linkColumns = [];
+        foreach ($exportFields as $name => $defs) {
+            $sheet ->setCellValue($col.$rowNumber, $defs['label']);
+            $sheet->getColumnDimension($col)->setAutoSize(true);
+            if ($defs['type'] == 'phone'
+                || $defs['type'] == 'email'
+                || $defs['type'] == 'url'
+                || $defs['type'] == 'link'
+                || $defs['type'] == 'linkParent'
+                || $defs['type'] == 'belongsTo'
+                || $defs['type'] == 'belongsToParent') {
+                $linkColumns[] = $col;
+            } else if ($name == 'name') {
+                $linkColumns[] = $col;
+            }
+            $col++;
+        }
+        $col = chr(ord($col) - 1);
+        $headerStyle = array(
+            'font'  => array(
+                'bold'  => true,
+                'size'  => 12
+            )
+        );
+        $sheet->getStyle("A$rowNumber:$col$rowNumber")->applyFromArray($headerStyle);
+        $sheet->setAutoFilter("A$rowNumber:$col$rowNumber");
+
+        // Data Section
+        $rowNumber++;
         foreach ($arr as $row) {
-            fputcsv($fp, $row, $delimiter);
-        }
-        rewind($fp);
-        $csv = stream_get_contents($fp);
-        fclose($fp);
+            $col = 'A';
+            foreach ($exportFields as $name => $defs) {
+                $link = null;
 
-        $fileName = "Export_{$this->entityType}.csv";
+                // Values //////////////////
+                if ($defs['type'] == 'link' || $defs['type'] == 'linkParent') {
+                    $sheet->setCellValue("$col$rowNumber", $row[$name.'Name']);
+                } else if ($defs['type'] == 'belongsTo') {
+                    $sheet->setCellValue("$col$rowNumber", $row[$name.'Name']);
+                } else if ($defs['type'] == 'belongsToParent') {
+                    $sheet->setCellValue("$col$rowNumber", $row[$name.'Name']);
+                } else if ($defs['type'] == 'personName') {
+                    if ($entityType == 'Contact') {
+                        $sheet->setCellValue("$col$rowNumber", $row['name']);
+                    } else {
+                        if ($row['firstName']) {
+                            $personName = $row['firstName'];
+                            if ($row['lastName']) {
+                                $personName .= " ".$row['lastName'];
+                            }
+                            $sheet->setCellValue("$col$rowNumber", $personName);
+                        } else if ($row['lastName']) {
+                            $sheet->setCellValue("$col$rowNumber", $row['lastName']);
+                        }
+                    }
+                } else if ($defs['type'] == 'int') {
+                    $sheet->setCellValue("$col$rowNumber", $row[$name] ?: 0);
+                } else if ($defs['type'] == 'date') {
+                    if (isset($row[$name])) {
+                        $sheet->setCellValue("$col$rowNumber", \PHPExcel_Shared_Date::PHPToExcel(strtotime($row[$name])));
+                    }
+                } else if ($defs['type'] == 'datetime' || $defs['type'] == 'datetimeOptional') {
+                    if (isset($row[$name])) {
+                        $sheet->setCellValue("$col$rowNumber", \PHPExcel_Shared_Date::PHPToExcel(strtotime($row[$name])));
+                    }
+                } else {
+                    $sheet->setCellValue("$col$rowNumber", $row[$name]);
+                }
+
+                // Links ///////////////////
+                if ($name == 'name') {
+                    $link = $this->getConfig()->get('siteUrl')."/#".$entityType."/view/".$row['id'];
+                } else if ($defs['type'] == 'url' && filter_var($row[$name], FILTER_VALIDATE_URL)) {
+                    $link = $row[$name];
+                } else if ($defs['type'] == 'link' || $defs['type'] == 'linkParent') {
+                    $link = $this->getConfig()->get('siteUrl')."/#".$defs['entity']."/view/".$row[$name.'Id'];
+                } else if ($defs['type'] == 'belongsTo') {
+                    $link = $this->getConfig()->get('siteUrl')."/#".$defs['entity']."/view/".$row[$name.'Id'];
+                } else if ($defs['type'] == 'belongsToParent') {
+                    $link = $this->getConfig()->get('siteUrl')."/#".$row[$name.'Type']."/view/".$row[$name.'Id'];
+                } else if ($defs['type'] == 'phone') {
+                    $link = "tel:".$row[$name];
+                } else if ($defs['type'] == 'email') {
+                    $link = "mailto:".$row[$name];
+                }
+
+                if ($link) {
+                    $sheet->getCell("$col$rowNumber")->getHyperlink()->setUrl($link);
+                    $sheet->getCell("$col$rowNumber")->getHyperlink()->setTooltip($link);
+                }
+                $col++;
+            }
+            $rowNumber++;
+        }
+
+        // Set format of columns
+        // EntityId column always text
+        $col = 'A';
+        foreach ($exportFields as $name => $defs) {
+            if ($col == 'A') {
+                $sheet->getStyle("A2:A$rowNumber")
+                    ->getNumberFormat()
+                    ->setFormatCode(\PHPExcel_Style_NumberFormat::FORMAT_TEXT);
+            } else {
+                switch($defs['type']) {
+                    case 'currency': {
+                        $sheet->getStyle($col.'3:'.$col.$rowNumber)
+                            ->getNumberFormat()
+                            ->setFormatCode('£#,##0_-');
+                    } break;
+
+                    case 'int': {
+                        $sheet->getStyle($col.'3:'.$col.$rowNumber)
+                            ->getNumberFormat()
+                            ->setFormatCode('0');
+                    } break;
+
+                    case 'date': {
+                        $sheet->getStyle($col.'3:'.$col.$rowNumber)
+                            ->getNumberFormat()
+                            ->setFormatCode('dd/mm/yyyy');
+                    } break;
+
+                    case 'datetime': {
+                        $sheet->getStyle($col.'3:'.$col.$rowNumber)
+                            ->getNumberFormat()
+                            ->setFormatCode('h:mm dd/mm/yyyy');
+                    } break;
+
+                    case 'datetimeOptional': {
+                        $sheet->getStyle($col.'3:'.$col.$rowNumber)
+                            ->getNumberFormat()
+                            ->setFormatCode('h:mm dd/mm/yyyy');
+                    } break;
+
+                    default: {
+                        $sheet->getStyle($col.'3:'.$col.$rowNumber)
+                            ->getNumberFormat()
+                            ->setFormatCode('@');
+                    } break;
+                }
+            }
+            $col++;
+        }
+
+        $linkStyle = [
+            'font'  => [
+                'color' => ['rgb' => '0000FF'],
+                'underline' => 'single'
+            ]
+        ];
+        foreach ($linkColumns as $linkColumn) {
+            $sheet->getStyle($linkColumn.'3:'.$linkColumn.$rowNumber)->applyFromArray($linkStyle);
+        }
+
+        // Hide Id Column
+        $sheet->getColumnDimension('A')->setVisible(false);
+
+        // Set active sheet index to the first sheet, so Excel opens this as the first sheet
+        $tempOutput = tempnam('/tmp/', 'ESPO');
+        $objWriter = \PHPExcel_IOFactory::createWriter($objPHPExcel, 'Excel2007');
+        $objWriter->save($tempOutput);
+
+        $fp = fopen($tempOutput, 'r');
+        $xlsx = stream_get_contents($fp);
+        fclose($fp);
+        unlink($tempOutput);
+
+        $todayDate = date('j_F_Hi');
+        $fileName = "Export_{$entityType}_{$todayDate}.xlsx";
 
         $attachment = $this->getEntityManager()->getEntity('Attachment');
         $attachment->set('name', $fileName);
         $attachment->set('role', 'Export File');
-        $attachment->set('type', 'text/csv');
+        $attachment->set('type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
 
         $this->getEntityManager()->saveEntity($attachment);
 
         if (!empty($attachment->id)) {
-            $this->getInjection('fileStorageManager')->putContents($attachment, $csv);
+            $this->getInjection('fileStorageManager')->putContents($attachment, $xlsx);
             // TODO cron job to remove file
             return $attachment->id;
         }

--- a/client/src/views/admin/layouts/export-fields.js
+++ b/client/src/views/admin/layouts/export-fields.js
@@ -2,7 +2,7 @@
  * This file is part of EspoCRM.
  *
  * EspoCRM - Open Source CRM application.
- * Copyright (C) 2014-2017 Yuri Kuznetsov, Taras Machyshyn, Oleksiy Avramenko
+ * Copyright (C) 2014-2015 Yuri Kuznetsov, Taras Machyshyn, Oleksiy Avramenko
  * Website: http://www.espocrm.com
  *
  * EspoCRM is free software: you can redistribute it and/or modify
@@ -26,7 +26,7 @@
  * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
  ************************************************************************/
 
-Espo.define('views/admin/layouts/filters', 'views/admin/layouts/rows', function (Dep) {
+Espo.define('views/admin/layouts/export-fields', 'views/admin/layouts/rows', function (Dep) {
 
     return Dep.extend({
 
@@ -113,7 +113,7 @@ Espo.define('views/admin/layouts/filters', 'views/admin/layouts/rows', function 
             if (this.ignoreList.indexOf(name) != -1) {
                 return false;
             }
-            return !model.getFieldParam(name, 'disabled') && !model.getFieldParam(name, 'layoutFiltersDisabled');
+            return !model.getFieldParam(name, 'disabled') && !model.getFieldParam(name, 'layoutExportsDisabled');
         }
 
     });

--- a/client/src/views/admin/layouts/index.js
+++ b/client/src/views/admin/layouts/index.js
@@ -40,6 +40,7 @@ Espo.define('views/admin/layouts/index', 'view', function (Dep) {
             'listSmall',
             'detailSmall',
             'filters',
+            'exportFields',
             'massUpdate',
             'relationships',
             'sidePanelsDetail',

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
 		"zendframework/zend-servicemanager": "2.6.0",
 		"tecnickcom/tcpdf": "^6.2",
 		"php-mime-mail-parser/php-mime-mail-parser": "^2.5",
-		"zbateson/mail-mime-parser": "^0.4.1"
+		"zbateson/mail-mime-parser": "^0.4.1",
+		"phpoffice/phpexcel": "^1.8"
 	},
 	"autoload": {
 		"psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6e1e3327b6081f402280ed7ad0c324f3",
-    "content-hash": "c98074c42af6b9e3396ae058bc602bea",
+    "hash": "064c61d7e728851cad5d703c85ade74d",
+    "content-hash": "02c2bb32ee1f881379ee82f5d375419d",
     "packages": [
         {
             "name": "composer/semver",
@@ -767,6 +767,63 @@
             "time": "2016-10-07 16:46:22"
         },
         {
+            "name": "phpoffice/phpexcel",
+            "version": "1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PHPExcel.git",
+                "reference": "372c7cbb695a6f6f1e62649381aeaa37e7e70b32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PHPExcel/zipball/372c7cbb695a6f6f1e62649381aeaa37e7e70b32",
+                "reference": "372c7cbb695a6f6f1e62649381aeaa37e7e70b32",
+                "shasum": ""
+            },
+            "require": {
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PHPExcel": "Classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL"
+            ],
+            "authors": [
+                {
+                    "name": "Maarten Balliauw",
+                    "homepage": "http://blog.maartenballiauw.be"
+                },
+                {
+                    "name": "Mark Baker"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "http://blog.rootslabs.net"
+                },
+                {
+                    "name": "Erik Tilt"
+                }
+            ],
+            "description": "PHPExcel - OpenXML - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+            "homepage": "http://phpexcel.codeplex.com",
+            "keywords": [
+                "OpenXML",
+                "excel",
+                "php",
+                "spreadsheet",
+                "xls",
+                "xlsx"
+            ],
+            "time": "2015-05-01 07:00:55"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.0",
             "source": {
@@ -911,7 +968,7 @@
                 "pdf417",
                 "qrcode"
             ],
-            "time": "2015-09-12 10:08:34"
+            "time": "2015-06-18 09:12:38"
         },
         {
             "name": "yzalis/identicon",


### PR DESCRIPTION
Hello,

See http://forum.espocrm.com/forum/developer-help/25889-excel-exports.

There's patches to Advanced Pack which I can share with you if you're interested in this. Most of the hard work is done - you could chose to offer a choice to users of CSV / and or Excel and maybe reinstate the Export fields modal window which I disabled in favour of saving a sane set of export fields for all users. (Right now CSV export is not that useful apart from machine reading).

Advanced Pack Report sending could gen an excel file and send it rather than the HTML email table too.

![exportlayout](https://cloud.githubusercontent.com/assets/7381617/24749318/890db776-1aba-11e7-9cdd-f83e620ed41d.png)

![tasks](https://cloud.githubusercontent.com/assets/7381617/24749314/84279bbe-1aba-11e7-803e-3e559e555956.jpg)


