### PR TITLE
Fix view name resolving for custom field types in merge action

### DIFF
--- a/client/src/views/record/merge.js
+++ b/client/src/views/record/merge.js
@@ -164,10 +164,10 @@ Espo.define('views/record/merge', 'view', function (Dep) {
             this.fields = differentFieldList;
 
             this.fields.forEach(function (field) {
-                var type = Espo.Utils.upperCaseFirst(this.models[0].getFieldParam(field, 'type'));
+                var type = this.models[0].getFieldParam(field, 'type');
 
                 this.models.forEach(function (model) {
-                    var viewName = model.getFieldParam(name, 'view') || this.getFieldManager().getViewName(type);
+                    var viewName = model.getFieldParam(field, 'view') || this.getFieldManager().getViewName(type);
 
                     this.createView(model.id + '-' + field, viewName, {
                         model: model,


### PR DESCRIPTION
In _FieldManager_, in _def_ object field types are stored with first char in lowercase. So for defined custom field types method _getViewName()_ returned view name without 'custom:' prefix (default behavior for not existing field type in _defs_ object) .
Also fixed argument typo on line 170.