### PR TITLE
Fix typo to have correct translation

### DIFF
--- a/client/modules/crm/src/views/mass-email/detail.js
+++ b/client/modules/crm/src/views/mass-email/detail.js
@@ -35,7 +35,7 @@ Espo.define('crm:views/mass-email/detail', 'views/detail', function (Dep) {
             if (~['Draft', 'Pending'].indexOf(this.model.get('status'))) {
                 if (this.getAcl().checkModel(this.model, 'edit')) {
                     this.menu.buttons.push({
-                        'label': 'Sent Test',
+                        'label': 'Send Test',
                         'action': 'sendTest',
                         'acl': 'edit'
                     });


### PR DESCRIPTION
In all the current translation files,
```
application/Espo/Modules/Crm/Resources/i18n/<language>/MassEmail.json
```

the key item is called `Send Test`

This PR fixes the view file `client/modules/crm/src/views/mass-email/detail.js` to have a correct translation of this item