### PR TITLE
Improve french translation: Campaign.json + MassEmail.json

### DIFF
--- a/application/Espo/Modules/Crm/Resources/i18n/fr_FR/MassEmail.json
+++ b/application/Espo/Modules/Crm/Resources/i18n/fr_FR/MassEmail.json
@@ -7,7 +7,7 @@
     "fromAddress": "Adresse de l’émetteur",
     "fromName": "Nom de l'expéditeur",
     "replyToAddress": "Addresse de réponse",
-    "replyToName": "Reply-to Name",
+    "replyToName": "Nom pour répondre",
     "campaign": "Campagne",
     "emailTemplate": "Modèle d'email",
     "inboundEmail": "Compte email",
@@ -39,7 +39,7 @@
   },
   "messages": {
     "selectAtLeastOneTarget": "Sélectionner au moins une cible",
-    "testSent": "Test email(s) supposed to be sent"
+    "testSent": "Le message de test est supposé être envoyé"
   },
   "tooltips": {
     "optOutEntirely": "Email addresses of recipients that unsubscribed will be marked as opted out and they will not receive any mass emails anymore.",


### PR DESCRIPTION
Improve french translation: Campaign.json + MassEmail.json

I checked on POEditor
https://poeditor.com/projects/po_edit?id_language=50&id=58283

but all keys were not able to be updated there :-( 

Let me know if this PR is suitable for you or if we should update in POEditor first to avoid to loose any changes?