### PR TITLE
MassMail Campaign: create a specific log when end-user clicks on Subs…

### DIFF
--- a/application/Espo/Modules/Crm/EntryPoints/SubscribeAgain.php
+++ b/application/Espo/Modules/Crm/EntryPoints/SubscribeAgain.php
@@ -122,16 +122,9 @@ class SubscribeAgain extends \Espo\Core\EntryPoints\Base
         }
 
         if ($campaign && $target) {
-            $logRecord = $this->getEntityManager()->getRepository('CampaignLogRecord')->where(array(
-                'queueItemId' => $queueItemId,
-                'action' => 'Opted Out'
-            ))->order('createdAt', true)->findOne();
-
-            if ($logRecord) {
-                $this->getEntityManager()->removeEntity($logRecord);
-            }
+            $campaignService = $this->getServiceFactory()->create('Campaign');
+            $campaignService->logOptedIn($campaignId, $queueItemId, $target, $queueItem->get('emailAddress'), null, $queueItem->get('isTest'));
         }
-
     }
 }
 

--- a/application/Espo/Modules/Crm/Resources/i18n/fr_FR/CampaignLogRecord.json
+++ b/application/Espo/Modules/Crm/Resources/i18n/fr_FR/CampaignLogRecord.json
@@ -20,6 +20,7 @@
     "action": {
       "Sent": "Envoyé",
       "Opened": "Ouvert",
+      "Opted In": "Inscrit",
       "Opted Out": "Désinscrit",
       "Bounced": "Renvoyé",
       "Clicked": "Cliqué",
@@ -32,6 +33,7 @@
   "presetFilters": {
     "sent": "Envoyé",
     "opened": "Ouvert",
+    "optedIn": "Inscrit",
     "optedOut": "Désinscrit",
     "bounced": "Bounced",
     "clicked": "Cliqué",

--- a/application/Espo/Modules/Crm/Resources/metadata/entityDefs/CampaignLogRecord.json
+++ b/application/Espo/Modules/Crm/Resources/metadata/entityDefs/CampaignLogRecord.json
@@ -4,7 +4,7 @@
             "type": "enum",
             "required": true,
             "maxLength": 50,
-            "options": ["Sent", "Opened", "Opted Out", "Bounced", "Clicked", "Lead Created"]
+            "options": ["Sent", "Opened", "Opted Out", "Opted In", "Bounced", "Clicked", "Lead Created"]
         },
         "actionDate": {
             "type": "datetime",

--- a/application/Espo/Modules/Crm/SelectManagers/CampaignLogRecord.php
+++ b/application/Espo/Modules/Crm/SelectManagers/CampaignLogRecord.php
@@ -86,6 +86,13 @@ class CampaignLogRecord extends \Espo\Core\SelectManagers\Base
         );
     }
 
+    protected function filterOptedIn(&$result)
+    {
+        $result['whereClause'][] = array(
+            'action' => 'Opted In'
+        );
+    }
+
     protected function filterOptedOut(&$result)
     {
         $result['whereClause'][] = array(

--- a/application/Espo/Modules/Crm/Services/Campaign.php
+++ b/application/Espo/Modules/Crm/Services/Campaign.php
@@ -217,6 +217,32 @@ class Campaign extends \Espo\Services\Record
         $this->getEntityManager()->saveEntity($logRecord);
     }
 
+    public function logOptedIn($campaignId, $queueItemId = null, Entity $target, $emailAddress = null, $actionDate = null, $isTest = false)
+    {
+        if ($queueItemId && $this->getEntityManager()->getRepository('CampaignLogRecord')->where(array(
+            'queueItemId' => $queueItemId,
+            'action' => 'Opted In',
+            'isTest' => $isTest
+        ))->findOne()) {
+            return;
+        }
+        if (empty($actionDate)) {
+            $actionDate = date('Y-m-d H:i:s');
+        }
+        $logRecord = $this->getEntityManager()->getEntity('CampaignLogRecord');
+        $logRecord->set(array(
+            'campaignId' => $campaignId,
+            'actionDate' => $actionDate,
+            'parentId' => $target->id,
+            'parentType' => $target->getEntityType(),
+            'action' => 'Opted In',
+            'stringData' => $emailAddress,
+            'queueItemId' => $queueItemId,
+            'isTest' => $isTest
+        ));
+        $this->getEntityManager()->saveEntity($logRecord);
+    }
+
     public function logOpened($campaignId, $queueItemId = null, Entity $target, $actionDate = null, $isTest = false)
     {
         if (empty($actionDate)) {

--- a/client/modules/crm/src/views/campaign-log-record/fields/data.js
+++ b/client/modules/crm/src/views/campaign-log-record/fields/data.js
@@ -48,6 +48,11 @@ Espo.define('Crm:Views.CampaignLogRecord.Fields.Data', 'Views.Fields.Base', func
                         return '<a href="#'+this.model.get('objectType')+'/view/'+this.model.get('objectId')+'">'+this.model.get('objectName')+'</a>';
                     }
     				return '<span>' + (this.model.get('stringData') || '') + '</span>';
+                case 'Opted In':
+                    if (this.model.get('objectId') && this.model.get('objectType') && this.model.get('objectName')) {
+                        return '<a href="#'+this.model.get('objectType')+'/view/'+this.model.get('objectId')+'">'+this.model.get('objectName')+'</a>';
+                    }
+                    return '<span>' + (this.model.get('stringData') || '') + '</span>';
                 case 'Opted Out':
                     return '<span class="text-danger">' + this.model.get('stringData') + '</span>';
                 case 'Bounced':

--- a/client/modules/crm/src/views/campaign/record/panels/campaign-log-records.js
+++ b/client/modules/crm/src/views/campaign/record/panels/campaign-log-records.js
@@ -31,7 +31,7 @@ Espo.define('crm:views/campaign/record/panels/campaign-log-records', 'views/reco
 
     return Dep.extend({
 
-    	filterList: ["all", "sent", "opened", "optedOut", "bounced", "clicked", "leadCreated"],
+    	filterList: ["all", "sent", "opened", "optedIn", "optedOut", "bounced", "clicked", "leadCreated"],
 
     	data: function () {
     		return _.extend({


### PR DESCRIPTION
MassMail Campaign: 
create a specific log when end-user clicks on SubscribeAgain link 
(and avoid to just remove optedOut log).

I think that's it's rather important to keep all logs related to end-users actions 
and know that a end-user really clicks on "opted out" link... and eventually on "subscribe again" link after that.

This pull request dont remove "optedOut" log but create a new log to track end-user clicks on "subscribe again" links.

Then, it's possible to display, in campaign record logs "OptedIn" logs + filter logs on this key.

Let me know what you think about it. 
We can rename the filter "Opted In" if it's not suitable for you :-) 