### PR TITLE
update diff to use util instead of sys

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -35,7 +35,7 @@ var acceptedVersionName = process.argv[3] || versionFrom;
 
 var path = require('path');
 var fs = require('fs');
-var sys = require('sys')
+var sys = require('util')
 
 var version = (require('./package.json') || {}).version;
 


### PR DESCRIPTION
Node sys changed to util a long time ago. Using sys shows a warning while util doesn't and util is a drop-in replacement for sys.