### PR TITLE
Fix #577: Replace default value for enum from "enum" to "varchar"

### DIFF
--- a/application/Espo/Resources/metadata/fields/enum.json
+++ b/application/Espo/Resources/metadata/fields/enum.json
@@ -12,7 +12,7 @@
       },
       {
          "name":"default",
-         "type":"enum",
+         "type":"varchar",
          "view": "views/admin/field-manager/fields/options/default"
       },
       {


### PR DESCRIPTION
### Problem
See #577. Also #477 looks related.

### Reason
Looking to very similar to `enum` fields such as [`enumFloat`](https://github.com/espocrm/espocrm/blob/master/application/Espo/Resources/metadata/fields/enumFloat.json#L9) and [`enumInt`](https://github.com/espocrm/espocrm/blob/master/application/Espo/Resources/metadata/fields/enumInt.json#L9), we could discover that types of `default` value there are `float` and `int`, while `enum` has `enum` as type of default value.

### Solution
Type of default value for `enum` should be replaced with `varchar`.