### PR TITLE
Fix #585: Verbose JSON::decode()

### DIFF
--- a/application/Espo/Core/Utils/Json.php
+++ b/application/Espo/Core/Utils/Json.php
@@ -68,14 +68,14 @@ class Json
             return false;
         }
 
-        $json = json_decode($json, $assoc);
+        $value = json_decode($json, $assoc);
 
         $error = self::getLastError();
         if ($error) {
-            $GLOBALS['log']->error('Json::decode():' . $error);
+            $GLOBALS['log']->error('Json::decode():' . $error . ' - ' . print_r($json, true));
         }
 
-        return $json;
+        return $value;
     }
 
     /**

--- a/application/Espo/Core/Utils/Json.php
+++ b/application/Espo/Core/Utils/Json.php
@@ -44,7 +44,7 @@ class Json
 
         $error = self::getLastError();
         if ($json === null || !empty($error)) {
-            $GLOBALS['log']->error('Json::encode():' . $error . ' - ' . print_r($value, true));
+            $GLOBALS['log']->error('Json::encode():' . $error . ' - ' . mb_substr(print_r($value, true), 0, 255));
         }
 
         return $json;
@@ -64,7 +64,7 @@ class Json
         }
 
         if (is_array($json)) {
-            $GLOBALS['log']->warning('Json::decode() - JSON cannot be decoded - '.$json);
+            $GLOBALS['log']->warning('Json::decode() - JSON cannot be decoded - ' . mb_substr($json, 0, 255));
             return false;
         }
 
@@ -72,7 +72,7 @@ class Json
 
         $error = self::getLastError();
         if ($error) {
-            $GLOBALS['log']->error('Json::decode():' . $error . ' - ' . print_r($json, true));
+            $GLOBALS['log']->error('Json::decode():' . $error . ' - ' . mb_substr($json, 0, 255));
         }
 
         return $value;


### PR DESCRIPTION
### Solution
Taking `JSON::encode()` as a basement and an example, added the value, that breaks JSON-decoding, to the log message.