### PR TITLE
Fix #590: Avoid IMAP error by unsetting recent flag

### DIFF
--- a/application/Espo/Services/EmailAccount.php
+++ b/application/Espo/Services/EmailAccount.php
@@ -310,6 +310,8 @@ class EmailAccount extends Record
 
                     if ($emailAccount->get('keepFetchedEmailsUnread')) {
                         if (is_array($flags) && empty($flags[Storage::FLAG_SEEN])) {
+                            // Recent flag may not be set.
+                            unset($flags[Storage::FLAG_RECENT]);
                             $storage->setFlags($id, $flags);
                         }
                     }


### PR DESCRIPTION
### Reason
IMAP can't handle setting `FLAG_RECENT`.

### Solution
Avoid passing `FLAG_RECENT` to `setFlags()`.