### PR TITLE
Dashlet: handle header option for calendar

### DIFF
--- a/application/Espo/Modules/Crm/Resources/metadata/dashlets/Calendar.json
+++ b/application/Espo/Modules/Crm/Resources/metadata/dashlets/Calendar.json
@@ -8,6 +8,11 @@
                 "type": "varchar",
                 "required": true
             },
+            "header": {
+                "type": "bool",
+                "default": false,
+                "required": true
+            },
             "autorefreshInterval": {
                 "type": "enumFloat",
                 "options": [0, 0.5, 1, 2, 5, 10]
@@ -31,6 +36,7 @@
         "defaults": {
             "autorefreshInterval": 0.5,
             "mode": "basicWeek",
+            "header": false,
             "enabledScopeList": ["Meeting", "Call", "Task"]
         },
         "layout": [
@@ -39,6 +45,10 @@
                     [
                         {"name": "title"},
                         {"name": "autorefreshInterval"}
+                    ],
+                    [
+                        {"name": "header"},
+                        false
                     ],
                     [
                         {"name": "mode"},

--- a/application/Espo/Resources/i18n/en_US/DashletOptions.json
+++ b/application/Espo/Resources/i18n/en_US/DashletOptions.json
@@ -8,6 +8,7 @@
         "isDoubleHeight": "Height 2x",
         "mode": "Mode",
         "enabledScopeList": "What to display",
+        "header": "Display header (navigation)",
         "users": "Users",
         "entityType": "Entity Type",
         "primaryFilter": "Primary Filter",

--- a/application/Espo/Resources/i18n/fr_FR/DashletOptions.json
+++ b/application/Espo/Resources/i18n/fr_FR/DashletOptions.json
@@ -8,6 +8,7 @@
     "isDoubleHeight": "Hauteur 2x",
     "mode": "Mode",
     "enabledScopeList": "Afficher",
+    "header": "Affichage entete navigation",
     "users": "Utilisateurs",
     "entityType": "Entity Type",
     "primaryFilter": "Primary Filter",

--- a/client/modules/crm/src/views/dashlets/calendar.js
+++ b/client/modules/crm/src/views/dashlets/calendar.js
@@ -66,7 +66,7 @@ Espo.define('crm:views/dashlets/calendar', 'views/dashlets/abstract/base', funct
                 this.createView('calendar', 'crm:views/calendar/calendar', {
                     mode: mode,
                     el: this.options.el + ' > .calendar-container',
-                    header: false,
+                    header: this.getOption('header'),
                     enabledScopeList: this.getOption('enabledScopeList'),
                     containerSelector: this.options.el
                 }, function (view) {


### PR DESCRIPTION
Currently, when using calendar dashlet, it's not possible to navigate through weeks.. months... 
in `dashlets/calendar.js`, header is set to false

End-user should be able to configure that option and decide if they want to display header or not.

I update `i18n/{en_US,fr_FR}/DashletOptions.json` file but i think POEditor entries should be updated?

Thanks for your support and review!
