### PR TITLE
Duplicate: re-create related links instead of just update the relation

### DIFF
--- a/application/Espo/Services/Record.php
+++ b/application/Espo/Services/Record.php
@@ -1757,7 +1757,14 @@ class Record extends \Espo\Core\Services\Base
         foreach ($this->duplicatingLinkList as $link) {
             $linkedList = $repository->findRelated($duplicatingEntity, $link);
             foreach ($linkedList as $linked) {
-                $repository->relate($entity, $link, $linked);
+                $arr = $linked->toArray();
+                $foreignIdName = lcfirst($this->entityType) . 'Id';
+                unset($arr[$foreignIdName]);
+                unset($arr['id']);
+                $newLinked = $this->getEntityManager()->getEntity($linked->getEntityName());
+                $newLinked->set($arr);
+                $newLinked->set($foreignIdName, $entity->id);
+                $this->getEntityManager()->saveEntity($newLinked);
             }
         }
     }


### PR DESCRIPTION
Hi @yurikuzn 
In my project this change was very important, and I hope you accept it.
If you want we may add a boolean member variable to the record service that enable or disable the re-creation