### PR TITLE
Array field: fix fetch search replace regexp if multi slash are present

### DIFF
--- a/client/src/views/fields/array.js
+++ b/client/src/views/fields/array.js
@@ -345,7 +345,7 @@ Espo.define('views/fields/array', ['views/fields/base', 'lib!Selectize'], functi
                 arr.push({
                     type: 'like',
                     field: field,
-                    value: "%" + value.replace(/\//, '\\\\/' ) + "%"
+                    value: "%" + value.replace(/\//g, '\\\\/' ) + "%"
                 });
                 arrFront.push(value);
             });


### PR DESCRIPTION
cf Tanya fixes ?
i didn't see it upstream

