### PR TITLE
Route: possibility to replace routes in modules

### DIFF
--- a/application/Espo/Core/Utils/Route.php
+++ b/application/Espo/Core/Utils/Route.php
@@ -112,17 +112,27 @@ class Route
         }
     }
 
+    /**
+     * Unify routes
+     *
+     * @return array
+     */
     protected function unify()
     {
-        $data = array();
+        // for custom
+        $data = $this->getAddData([], $this->paths['customPath']);
 
-        $data = $this->getAddData($data, $this->paths['customPath']);
-
+        // for module
+        $moduleData = [];
         foreach ($this->getMetadata()->getModuleList() as $moduleName) {
             $modulePath = str_replace('{*}', $moduleName, $this->paths['modulePath']);
-            $data = $this->getAddData($data, $modulePath);
+            foreach ($this->getAddData([], $modulePath) as $row) {
+                $moduleData[$row['method'].$row['route']] = $row;
+            }
         }
+        $data = array_merge($data, array_values($moduleData));
 
+        // for core
         $data = $this->getAddData($data, $this->paths['corePath']);
 
         return $data;


### PR DESCRIPTION
This modification will allow to redefine the routes in the modules. That is, each subsequent loaded module can change the controller that processes the request. It gives more flexibility to the system, because very often one module extends the previous one, etc.