### PR TITLE
CronManager to Loaders

### DIFF
--- a/application/Espo/Core/Application.php
+++ b/application/Espo/Core/Application.php
@@ -136,7 +136,7 @@ class Application
         $auth = $this->createAuth();
         $auth->useNoAuth();
 
-        $cronManager = new \Espo\Core\CronManager($this->container);
+        $cronManager = $this->getContainer()->get('cronManager');
         $cronManager->run();
     }
 

--- a/application/Espo/Core/Loaders/CronManager.php
+++ b/application/Espo/Core/Loaders/CronManager.php
@@ -1,0 +1,44 @@
+<?php
+/* * **********************************************************************
+ * This file is part of EspoCRM.
+ *
+ * EspoCRM - Open Source CRM application.
+ * Copyright (C) 2014-2017 Yuri Kuznetsov, Taras Machyshyn, Oleksiy Avramenko
+ * Website: http://www.espocrm.com
+ *
+ * EspoCRM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EspoCRM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EspoCRM. If not, see http://www.gnu.org/licenses/.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
+ * ********************************************************************** */
+
+namespace Espo\Core\Loaders;
+
+class CronManager extends Base
+{
+
+    /**
+     * Load CronManager
+     *
+     * @return \Espo\Core\CronManager
+     */
+    public function load()
+    {
+        return new \Espo\Core\CronManager($this->getContainer());
+    }
+}


### PR DESCRIPTION
CronManager is better to load by Loaders. It gives more flexibility for the system. With this feature we can replace or extend CronManager in modules.