### PR TITLE
enable loadAdditionalFields in API operations via configuration

### DIFF
--- a/application/Espo/Services/Record.php
+++ b/application/Espo/Services/Record.php
@@ -574,6 +574,11 @@ class Record extends \Espo\Core\Services\Base
         if ($this->storeEntity($entity)) {
             $this->afterCreateEntity($entity, $data);
             $this->afterCreateProcessDuplicating($entity, $data);
+
+            if ($this->getConfig()->get('apiAlwaysLoadAdditionalFields')) {
+                $this->loadAdditionalFields($entity);
+            }
+
             $this->prepareEntityForOutput($entity);
 
             $this->processActionHistoryRecord('create', $entity);
@@ -634,6 +639,11 @@ class Record extends \Espo\Core\Services\Base
 
         if ($this->storeEntity($entity)) {
             $this->afterUpdateEntity($entity, $data);
+
+            if ($this->getConfig()->get('apiAlwaysLoadAdditionalFields')) {
+                $this->loadAdditionalFields($entity);
+            }
+
             $this->prepareEntityForOutput($entity);
 
             $this->processActionHistoryRecord('update', $entity);


### PR DESCRIPTION
The API currently doesn't return the same entity during create and update operations compared to read operations, which can be a little confusing. I think this could be a useful feature if it doesn't hurt to check for a configuration parameter.