### PR TITLE
relationship view: ability to skip collection select

### DIFF
--- a/client/src/views/record/panels/relationship.js
+++ b/client/src/views/record/panels/relationship.js
@@ -42,6 +42,8 @@ Espo.define('views/record/panels/relationship', ['views/record/panels/bottom', '
 
         fetchOnModelAfterRelate: false,
 
+        skipCollectionSelect: false,
+
         init: function () {
             Dep.prototype.init.call(this);
         },
@@ -196,12 +198,16 @@ Espo.define('views/record/panels/relationship', ['views/record/panels/bottom', '
                         el: this.options.el + ' .list-container',
                         skipBuildRows: true
                     }, function (view) {
-                        view.getSelectAttributeList(function (selectAttributeList) {
-                            if (selectAttributeList) {
-                                collection.data.select = selectAttributeList.join(',');
-                            }
+                        if (this.skipCollectionSelect) {
                             collection.fetch();
-                        }.bind(this));
+                        } else {
+                            view.getSelectAttributeList(function (selectAttributeList) {
+                                if (selectAttributeList) {
+                                    collection.data.select = selectAttributeList.join(',');
+                                }
+                                collection.fetch();
+                            }.bind(this));
+                        }
                     });
                 }, this);
 


### PR DESCRIPTION
Hi Yuri
Please look at this change if is applicable or not, because it is sometimes very important to retrieve all the values in custom relationship views