### PR TITLE
Allow changing name of the default filter name

### DIFF
--- a/client/res/templates/record/search.tpl
+++ b/client/res/templates/record/search.tpl
@@ -9,7 +9,7 @@
                 </button>
                 <ul class="dropdown-menu pull-left filter-menu">
 
-                    <li><a class="preset" tabindex="-1" href="javascript:" data-name="" data-action="selectPreset"><div>{{translate 'All'}}</div></a></li>
+                    <li><a class="preset" tabindex="-1" href="javascript:" data-name="" data-action="selectPreset"><div>{{translate 'all' category='presetFilters' scope=entityType}}</div></a></li>
                     {{#each presetFilterList}}
                     <li><a class="preset" tabindex="-1" href="javascript:" data-name="{{name}}" data-action="selectPreset"><div>{{#if label}}{{label}}{{else}}{{translate name category='presetFilters' scope=../../entityType}}{{/if}}</div></a></li>
                     {{/each}}

--- a/client/src/views/record/search.js
+++ b/client/src/views/record/search.js
@@ -523,7 +523,7 @@ Espo.define('views/record/search', 'view', function (Dep) {
 
             this.$el.find('ul.filter-menu a.preset span').remove();
 
-            var filterLabel = this.translate('All');
+            var filterLabel = this.translate('all', 'presetFilters', this.entityType);
             var filterStyle = 'default';
 
             if (!presetName && primary) {


### PR DESCRIPTION
Default filter name (literally 'All') can be translated for each entity.
It's useful when filter code is changed in SelectManager class.