### PR TITLE
small fix to activities service

### DIFF
--- a/application/Espo/Modules/Crm/Services/Activities.php
+++ b/application/Espo/Modules/Crm/Services/Activities.php
@@ -1054,8 +1054,6 @@ class Activities extends \Espo\Core\Services\Base
         }
 
         if ($seed->hasRelation('assignedUsers')) {
-            $selectManager->setDistinct(true, $selectParams);
-            $selectManager->addLeftJoin(['assignedUsers', 'assignedUsers'], $selectParams);
             $wherePart['assignedUsersMiddle.userId'] = $userId;
         }
 
@@ -1094,6 +1092,7 @@ class Activities extends \Espo\Core\Services\Base
         }
 
         if ($seed->hasRelation('assignedUsers')) {
+            $selectManager->setDistinct(true, $selectParams);
             $selectParams['leftJoins'][] = 'assignedUsers';
         }
 


### PR DESCRIPTION
`$selectParams` in the line [L1057](https://github.com/espocrm/espocrm/blob/master/application/Espo/Modules/Crm/Services/Activities.php#L1057) was not defined because of being before `$selectParams` initialized, so I moved it to be after.
`$selectManager->addLeftJoin(['assignedUsers', 'assignedUsers'], $selectParams); `seems not needed as it is added in the line 1095