### PR TITLE
 Allows Entry Points of Specific modules to be customized/overridden

### DIFF
--- a/application/Espo/Core/EntryPointManager.php
+++ b/application/Espo/Core/EntryPointManager.php
@@ -53,7 +53,7 @@ class EntryPointManager
         'corePath' => 'application/Espo/EntryPoints',
         'modulePath' => 'application/Espo/Modules/{*}/EntryPoints',
         'customPath' => 'custom/Espo/Custom/EntryPoints',
-	'customModulePath' => 'custom/Espo/Custom/Modules/{*}/EntryPoints'
+        'customModulePath' => 'custom/Espo/Custom/Modules/{*}/EntryPoints'
     );
 
 

--- a/application/Espo/Core/EntryPointManager.php
+++ b/application/Espo/Core/EntryPointManager.php
@@ -53,6 +53,7 @@ class EntryPointManager
         'corePath' => 'application/Espo/EntryPoints',
         'modulePath' => 'application/Espo/Modules/{*}/EntryPoints',
         'customPath' => 'custom/Espo/Custom/EntryPoints',
+	'customModulePath' => 'custom/Espo/Custom/Modules/{*}/EntryPoints'
     );
 
 

--- a/application/Espo/Core/Utils/File/ClassParser.php
+++ b/application/Espo/Core/Utils/File/ClassParser.php
@@ -105,6 +105,14 @@ class ClassParser
                 }
             }
 
+            if (isset($paths['customModulePath'])) {
+                foreach ($this->getMetadata()->getModuleList() as $moduleName) {
+                    $path = str_replace('{*}', $moduleName, $paths['customModulePath']);
+
+                    $data = array_merge($data, $this->getClassNameHash($path));
+                }
+            }
+
             if (isset($paths['customPath'])) {
                 $data = array_merge($data, $this->getClassNameHash($paths['customPath']));
             }


### PR DESCRIPTION
Currently, Modules can have their own EntryPoints, but they cannot be customized. This patch fixes that.