### PR TITLE
list record: enable top bar in  if display Total Count is true

### DIFF
--- a/client/src/views/record/list.js
+++ b/client/src/views/record/list.js
@@ -335,6 +335,7 @@ Espo.define('views/record/list', 'view', function (Dep) {
         data: function () {
             var paginationTop = this.pagination === 'both' || this.pagination === true || this.pagination === 'top';
             var paginationBottom = this.pagination === 'both' || this.pagination === true || this.pagination === 'bottom';
+            var displayTotalCount = this.displayTotalCount && this.collection.total > 0;
 
             var moreCount = this.collection.total - this.collection.length;
 
@@ -349,6 +350,7 @@ Espo.define('views/record/list', 'view', function (Dep) {
             var topBar =
                 paginationTop ||
                 this.checkboxes ||
+                this.displayTotalCount ||
                 (this.buttonList.length && !this.buttonsDisabled) ||
                 (this.dropdownItemList.length && !this.buttonsDisabled) ||
                 this.forceDisplayTopBar;
@@ -373,7 +375,7 @@ Espo.define('views/record/list', 'view', function (Dep) {
                 checkAllResultDisabled: checkAllResultDisabled,
                 buttonList: this.buttonList,
                 dropdownItemList: this.dropdownItemList,
-                displayTotalCount: this.displayTotalCount && this.collection.total > 0,
+                displayTotalCount: displayTotalCount,
                 displayActionsButtonGroup: this.checkboxes || this.massActionList || this.buttonList.length || this.dropdownItemList.length,
                 totalCountFormatted: this.getNumberUtil().formatInt(this.collection.total),
                 moreCountFormatted: this.getNumberUtil().formatInt(moreCount),


### PR DESCRIPTION
Hi Yuri, this time I made a lot of tests, and I found something while I was looking for another solution.

I found that you already have an option [showCount](https://github.com/espocrm/espocrm/blob/master/client/src/views/record/list.js#L1038), as you can see this option can override the value of `displayTotalCount` so you have no problem, for lists that not need to display the top bar at all, you only need to pass `'showCount': false`

**TL;DR** if  `'showCount': false` then this PR change will be overridden and ignored. 

for example, you used it [here](https://github.com/espocrm/espocrm/blob/117084f8359eeea7432c3d9d58bbbabf256220cb/client/src/views/notification/list.js#L65) and [here](https://github.com/espocrm/espocrm/blob/ce2fe9d50c89d32fa39f93b035e899688e87fdf7/client/src/views/notification/panel.js#L68) and [here](https://github.com/espocrm/espocrm/blob/4ceb22c0ada60356fc75a82be0e8480ea414bd95/client/src/views/record/list-tree.js#L37)