### PR TITLE
Fix getLevel method in acl manager

### DIFF
--- a/client/src/acl-manager.js
+++ b/client/src/acl-manager.js
@@ -95,7 +95,7 @@ define('acl-manager', ['acl'], function (Acl) {
 
         getLevel: function (scope, action) {
             if (!(scope in this.data.table)) return;
-            if (!(action in this.data.table[scope])) return;
+            if (typeof this.data.table[scope] !== 'object' || !(action in this.data.table[scope])) return;
 
             return this.data.table[scope][action];
         },


### PR DESCRIPTION
Hello.
If set disabled entity permission the ACL table would contain boolean value `false` for this entity. So in method getLevel we should check if `this.data.table[scope]` is object for using `in` operator then. In other case it cause error `Uncaught TypeError: Cannot use 'in' operator to search for 'read' in false`