### PR TITLE
Show localized labels in header instead of fields names

### DIFF
--- a/application/Espo/Core/Export/Csv.php
+++ b/application/Espo/Core/Export/Csv.php
@@ -37,19 +37,87 @@ class Csv extends \Espo\Core\Injectable
 {
     protected $dependencyList = [
         'config',
-        'preferences',
-        'metadata'
+        'language',
+        'metadata',
+        'preferences'
     ];
+
+    protected function getConfig()
+    {
+        return $this->getInjection('config');
+    }
+
+    protected function getMetadata()
+    {
+        return $this->getInjection('metadata');
+    }
+
+    protected function getLanguage()
+    {
+        return $this->getInjection('language');
+    }
 
     public function loadAdditionalFields(Entity $entity, $fieldList)
     {
+        foreach ($entity->getRelationList() as $link) {
+            if (in_array($link, $fieldList)) {
+                if ($entity->getRelationType($link) === 'belongsToParent') {
+                    if (!$entity->get($link . 'Name')) {
+                        $entity->loadParentNameField($link);
+                    }
+                } else if (
+                    (
+                        (
+                            $entity->getRelationType($link) === 'belongsTo'
+                            &&
+                            $entity->getRelationParam($link, 'noJoin')
+                        )
+                        ||
+                        $entity->getRelationType($link) === 'hasOne'
+                    )
+                    &&
+                    $entity->hasAttribute($link . 'Name')
+                ) {
+                    if (!$entity->get($link . 'Name') || !$entity->get($link . 'Id')) {
+                        $entity->loadLinkField($link);
+                    }
+                }
+            }
+        }
         foreach ($fieldList as $field) {
-            if ($this->getInjection('metadata')->get(['entityDefs', $entity->getEntityType(), 'fields', $field, 'type']) === 'linkMultiple') {
+            if ($this->getMetadata()->get(['entityDefs', $entity->getEntityType(), 'fields', $field, 'type']) === 'linkMultiple') {
                 if (!$entity->has($field . 'Ids')) {
                     $entity->loadLinkMultipleField($field);
                 }
             }
         }
+    }
+
+    private function translate($label, $category, $scope, $requiredOptions = null)
+    {
+        return $this->getLanguage()->translate($label, $category, $scope, $requiredOptions);
+    }
+
+    private function translateField($fieldName)
+    {
+        $defs = $this->getMetadata()->get(['entityDefs', $entityType, 'fields', $name]);
+
+        if (!$defs) {
+            $defs['type'] = 'base';
+        }
+        
+        $label = $fieldName;
+        if (strpos($name, '_') !== false) {
+            list($linkName, $foreignField) = explode('_', $fieldName);
+            $foreignScope = $this->getMetadata()->get(['entityDefs', $entityType, 'links', $linkName, 'entity']);
+            if ($foreignScope) {
+                $label = $this->translate($linkName, 'links', $entityType) . '.' . $this->translate($foreignField, 'fields', $foreignScope);
+            }
+        } else {
+            $label = $this->translate($fieldName, 'fields', $entityType);
+        }
+        
+        return $label;
     }
 
     public function process(string $entityType, array $params, ?array $dataList, $dataFp = null)
@@ -59,14 +127,23 @@ class Csv extends \Espo\Core\Injectable
         }
 
         $attributeList = $params['attributeList'];
+        $fieldList = $params['fieldList'];
 
         $delimiter = $this->getInjection('preferences')->get('exportDelimiter');
         if (empty($delimiter)) {
-            $delimiter = $this->getInjection('config')->get('exportDelimiter', ';');
+            $delimiter = $this->getConfig()->get('exportDelimiter', ';');
         }
 
         $fp = fopen('php://temp', 'w');
-        fputcsv($fp, $attributeList, $delimiter);
+        
+        $attributeListTranslated = [];
+
+        foreach ($attributeList as $i => $name) {
+            $attributeListTranslated[] = $this->translateField($name);
+        }
+
+        fprintf($fp, chr(0xEF).chr(0xBB).chr(0xBF)); // UTF-8
+        fputcsv($fp, $attributeListTranslated, $delimiter);
 
         if ($dataFp) {
             while (($line = fgets($dataFp)) !== false) {


### PR DESCRIPTION
In CSV export header, now we show localized labels instead of field names.