### PR TITLE
fix: override login view from config

### DIFF
--- a/client/src/controllers/base.js
+++ b/client/src/controllers/base.js
@@ -31,7 +31,7 @@ define('controllers/base', 'controller', function (Dep) {
     return Dep.extend({
 
         login: function () {
-            var viewName = this.getMetadata().get(['clientDefs', 'App', 'loginView']) || 'views/login';
+            var viewName = this.getConfig().get('loginView') || 'views/login';
             this.entire(viewName, {}, function (login) {
                 login.render();
                 login.on('login', function (data) {


### PR DESCRIPTION
It is a nice feature to be able to override the login view, and it is already has been implemented,
but the problem is that metadata will not initialized before the login,
I hope to accept this change