### PR TITLE
Rendering of Multi-Enum fields on export to XLSX

### DIFF
--- a/application/Espo/Core/Export/Xlsx.php
+++ b/application/Espo/Core/Export/Xlsx.php
@@ -416,6 +416,10 @@ class Xlsx extends \Espo\Core\Injectable
                         }
                         $sheet->setCellValue("$col$rowNumber", $value);
                     }
+                } else if ($type == 'multiEnum') {
+                    $value = trim($row[$name], '[]');
+                    $value = str_replace('"', '', $value);
+                    $sheet->setCellValue("$col$rowNumber", $value);
                 } else if ($type == 'linkMultiple') {
                     if (array_key_exists($name . 'Ids', $row) && array_key_exists($name . 'Names', $row)) {
                         $nameList = [];


### PR DESCRIPTION
Now Multi-Enum fields are exported to XLSX as _["Value1","Value2"]_
My goal is to restore behavior from version 4.x, remove brackets and quotes – _Value1,Value2_