### PR TITLE
Add 'Today' button to bootstrap datepicker

### DIFF
--- a/client/src/views/fields/date.js
+++ b/client/src/views/fields/date.js
@@ -161,6 +161,7 @@ Espo.define('views/fields/date', 'views/fields/base', function (Dep) {
                     weekStart: this.getDateTime().weekStart,
                     autoclose: true,
                     todayHighlight: true,
+                    todayBtn: true,
                 };
 
                 var language = this.getConfig().get('language');


### PR DESCRIPTION
Bootstrap has a default 'Today' button placed at the bottom of bootstrap datepicker. It is inoffensive for those who don't need it, but quite useful for those who need to set up many date fields.