### PR TITLE
Feature: show/hide fields on record views in edit mode with dynamic conditions

### DIFF
--- a/client/src/dynamic-logic.js
+++ b/client/src/dynamic-logic.js
@@ -31,6 +31,9 @@ define('dynamic-logic', [], function () {
     var DynamicLogic = function (defs, recordView) {
         this.defs = defs || {};
         this.recordView = recordView;
+        
+        recordView.on('after:set-edit-mode', function() { this.process() }.bind(this));
+        recordView.on('after:set-detail-mode', function() { this.process() }.bind(this));
 
         this.fieldTypeList = ['visible', 'required', 'readOnly'];
         this.panelTypeList = ['visible'];
@@ -145,6 +148,9 @@ define('dynamic-logic', [], function () {
             if (~['or', 'and', 'not'].indexOf(type)) {
                 return this.checkConditionGroup(defs.value, type);
             }
+            
+            if(type === 'onEdit')
+                return this.recordView.mode === 'edit';
 
             var attribute = defs.attribute;
             var value = defs.value;


### PR DESCRIPTION
This will add the dynamic condition type `onEdit` which can be used to hide panels/fields in record detail views when in detail mode. We used it to add important notes (read-only text fields with default values) to the detail view while in edit mode.
It's just a little change but - at least for us - had a great improve in quality of workflow processing.

```json
"conditionGroup": [
    {
        "type": "onEdit"
    }
]
```