### PR TITLE
Test related changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,49 @@ Build json files from the translated po file:
 
 Json files will be created in build directory grouped by folders.
 
+### Running Tests
+
+First get PHPUnit 8
+
+```console
+$ wget -O phpunit https://phar.phpunit.de/phpunit-8.phar
+$ chmod +x phpunit
+$ ./phpunit --version
+```
+
+#### Running All Tests
+
+This will run both integration and unit test. You may want to run unit test and integration tests separately which is documented below.
+
+```console
+$ ./phpunit
+```
+
+#### Running Unit Tests Only
+
+```console
+$ ./phpunit --testsuite=Unit
+```
+
+#### Running Integration Tests Only
+
+**Note: Integration tests are very slow**
+
+```console
+$ ./phpunit --testsuite=Integration
+```
+
+#### Running Tests without Using Configurations
+
+```console
+$ ./phpunit --no-configuration --bootstrap=vendor/autoload.php tests/unit 
+$ ./phpunit --no-configuration --bootstrap=vendor/autoload.php tests/integration 
+```
+
+#### Code Coverage Analysis
+
+Load [Coverage Report](./coverage-report/index.html) in the browser of your local machine once one of the above test with configurations have been run. You can navigate between folders and files to see what is covered in php tests and what is not!
+
 ### License
 
 EspoCRM is published under the GNU GPLv3 [license](https://raw.githubusercontent.com/espocrm/espocrm/master/LICENSE.txt).

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,31 @@
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+         verbose="true"
+         stopOnFailure="false"
+         testdox="true">
+    <testsuites>
+        <testsuite name="Integration">
+            <directory suffix="Test.php">./tests/integration/</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/unit/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <!-- This is for generating code coverage analysis which will appear in espocrm/coverage-report folder -->
+            <directory suffix=".php">application/Espo/</directory>
+            <exclude>
+                <directory suffix=".php">
+                    <!-- This is because the coverage conflicts with the files defined in tests/unit/testData/DB/Entities.php -->
+                    application/Espo/Entities
+                </directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-html" target="coverage-report" lowUpperBound="35" highLowerBound="70"/>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
+        <log type="testdox-html" target="/tmp/testdox.html"/>
+    </logging>
+</phpunit>

--- a/tests/unit/Espo/Core/ApplicationTest.php
+++ b/tests/unit/Espo/Core/ApplicationTest.php
@@ -1,0 +1,132 @@
+<?php
+/************************************************************************
+ * This file is part of EspoCRM.
+ *
+ * EspoCRM - Open Source CRM application.
+ * Copyright (C) 2014-2019 Yuri Kuznetsov, Taras Machyshyn, Oleksiy Avramenko
+ * Website: https://www.espocrm.com
+ *
+ * EspoCRM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EspoCRM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EspoCRM. If not, see http://www.gnu.org/licenses/.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
+ ************************************************************************/
+
+namespace tests\unit\Espo\Core;
+
+use tests\unit\ReflectionHelper;
+
+/**
+ * Contains tests for application class
+ */
+class ApplicationTest extends \PHPUnit\Framework\TestCase
+{
+
+    private $app = null;
+
+    private $reflectionOfApp = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        
+    }
+
+    public function setUp(): void
+    {
+        $this->app = new \Espo\Core\Application();
+        $this->reflectionOfApp = new ReflectionHelper($this->app);
+    }
+
+    /**
+     * @test
+     */
+    public function createAuth()
+    {
+        $auth = $this->reflectionOfApp->invokeMethod("createAuth", [$this->app->getContainer()]);
+        $this->assertInstanceOf(\Espo\Core\Utils\Auth::class, $auth);
+    }
+
+    /**
+     * @test
+     */
+    public function getSlim()
+    {
+        $slim = $this->app->getSlim();
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function isInstalledTrue()
+    {
+        // Mock the config because config tells whether app is installed or not
+        $configDouble = $this->getMockBuilder(\Espo\Core\Utils\Config::class)
+                                ->disableOriginalConstructor()
+                                ->setMethods(["getConfigPath", "get"])
+                                ->getMock();
+
+        // Mock getConfigPath to always return "application/Espo/Core/defaults/config.php" as return response
+        $configDouble->method("getConfigPath")->willReturn("application/Espo/Core/defaults/config.php");
+
+        // Mock get to always return true
+        // With tells the exact parameters sent to the get function
+        $configDouble->method("get")->with($this->stringContains("isInstalled"))->willReturn(true);
+
+        // Use reflection helper to update the existing container config object with its test double.
+        $containerReflection = new ReflectionHelper($this->app->getContainer());
+        $containerReflection->setProperty("data", ["config" => $configDouble]);
+
+        // Run the assertion
+        $this->assertTrue($this->app->isInstalled());
+    }
+
+    /**
+     * @test
+     */
+    public function isInstalledFalse()
+    {
+        // Mock the config because config tells whether app is installed or not
+        $configDouble = $this->getMockBuilder(\Espo\Core\Utils\Config::class)
+                                ->disableOriginalConstructor()
+                                ->setMethods(["getConfigPath", "get"])
+                                ->getMock();
+
+        // Mock getConfigPath to always return "application/Espo/Core/defaults/config.php" as return response
+        $configDouble->method("getConfigPath")->willReturn("application/Espo/Core/defaults/config.php");
+
+        // Mock get to always return true
+        $configDouble->method("get")->with($this->stringContains("isInstalled"))->willReturn(false);
+
+        // Use reflection helper to update the existing container config object with its test double.
+        $containerReflection = new ReflectionHelper($this->app->getContainer());
+        $containerReflection->setProperty("data", ["config" => $configDouble]);
+
+        // Run the assertion
+        $this->assertFalse($this->app->isInstalled());
+    }
+
+    public function tearDown(): void
+    {
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+
+    }
+}


### PR DESCRIPTION
- Created testsuites using phpunit.xml
  - code coverage with whitelisting directories etc...
  - testdox 
  - `./phpunit` will run all tests
  - `./phpunit --testsuite=Unit` to run unit test
  - `./phpunit --testsuite=Integration` to run Integration test
  - phpunit.xml has configurations that will show test's code-coverage. This is so that it can help you to add new tests.
- new tests: added some new tests for \Espo\Core\Application
- Updated Readme on how to run tests