### PR TITLE
Increase logging of many-to-many relation operations and log invalid foreach parameter error for mid keys

### DIFF
--- a/application/Espo/Core/Utils/Database/Schema/Converter.php
+++ b/application/Espo/Core/Utils/Database/Schema/Converter.php
@@ -282,6 +282,9 @@ class Converter
     protected function prepareManyMany($entityName, $relationParams, $tables)
     {
         $tableName = Util::toUnderScore($relationParams['relationName']);
+        $GLOBALS['log']->debug('DBAL: prepareManyMany invoked for ' . $entityName, [
+            'tableName' => $tableName, 'parameters' => $relationParams
+        ]);
 
         if ($this->getSchema()->hasTable($tableName)) {
             $GLOBALS['log']->debug('DBAL: Table ['.$tableName.'] exists.');
@@ -297,17 +300,22 @@ class Converter
 
         //add midKeys to a schema
         $uniqueIndex = array();
-        foreach($relationParams['midKeys'] as $index => $midKey) {
-
-            $columnName = Util::toUnderScore($midKey);
-            $table->addColumn($columnName, $this->idParams['dbType'], $this->getDbFieldParams(array(
-                'type' => 'foreignId',
-                'len' => $this->idParams['len'],
-            )));
-            $table->addIndex(array($columnName), SchemaUtils::generateIndexName($columnName));
-
-            $uniqueIndex[] = $columnName;
-        }
+        if (empty($relationParams['midKeys'])) {
+            $GLOBALS['log']->debug('REBUILD: midKeys are empty!', [
+                'scope' => $entityName, 'tableName' => $tableName,
+                'parameters' => $relationParams
+            ]);
+        } else {
+            foreach($relationParams['midKeys'] as $index => $midKey) {
+                $columnName = Util::toUnderScore($midKey);
+                $table->addColumn($columnName, $this->idParams['dbType'], $this->getDbFieldParams(array(
+                    'type' => 'foreignId',
+                    'len' => $this->idParams['len'],
+                )));
+                $table->addIndex(array($columnName), SchemaUtils::generateIndexName($columnName));
+                $uniqueIndex[] = $columnName;
+            }
+        }        
         //END: add midKeys to a schema
 
         //add additionalColumns


### PR DESCRIPTION
This is my first contribution to Espo to fix #1576 but the second try. 😄

It was originally meant for master but then I remembered hotfix should be used for fixes, so I re-created the change with the hotfix branch. Please forgive me for any error!!