### PR TITLE
Implementing feature 'Skip rebuild'

### DIFF
--- a/application/Espo/Core/Utils/Database/Orm/Converter.php
+++ b/application/Espo/Core/Utils/Database/Orm/Converter.php
@@ -172,6 +172,8 @@ class Converter
                 continue;
             }
 
+            $ormMetadata[$entityName]['skipRebuild'] = $entityMetadata['skipRebuild'] ?? false;
+
             $ormMetadata = Util::merge($ormMetadata, $this->convertEntity($entityName, $entityMetadata));
         }
 

--- a/application/Espo/Core/Utils/Database/Orm/Converter.php
+++ b/application/Espo/Core/Utils/Database/Orm/Converter.php
@@ -172,7 +172,7 @@ class Converter
                 continue;
             }
 
-            $ormMetadata[$entityName]['skipRebuild'] = $entityMetadata['skipRebuild'] ?? false;
+            if ($entityMetadata['skipRebuild'] ?? false) $ormMetadata[$entityName]['skipRebuild'] = true;
 
             $ormMetadata = Util::merge($ormMetadata, $this->convertEntity($entityName, $entityMetadata));
         }

--- a/application/Espo/Core/Utils/Database/Schema/Converter.php
+++ b/application/Espo/Core/Utils/Database/Schema/Converter.php
@@ -186,7 +186,7 @@ class Converter
         $tables = array();
         foreach ($ormMeta as $entityName => $entityParams) {
 
-            if ($entityParams['skipRebuild']) continue;
+            if ($entityParams['skipRebuild'] ?? false) continue;
 
             $tableName = Util::toUnderScore($entityName);
 

--- a/application/Espo/Core/Utils/Database/Schema/Converter.php
+++ b/application/Espo/Core/Utils/Database/Schema/Converter.php
@@ -186,6 +186,8 @@ class Converter
         $tables = array();
         foreach ($ormMeta as $entityName => $entityParams) {
 
+            if ($entityParams['skipRebuild']) continue;
+
             $tableName = Util::toUnderScore($entityName);
 
             if ($schema->hasTable($tableName)) {
@@ -315,7 +317,7 @@ class Converter
                 $table->addIndex(array($columnName), SchemaUtils::generateIndexName($columnName));
                 $uniqueIndex[] = $columnName;
             }
-        }        
+        }
         //END: add midKeys to a schema
 
         //add additionalColumns

--- a/contributors/unitorzero.md
+++ b/contributors/unitorzero.md
@@ -1,0 +1,5 @@
+I hereby agree to the terms of the EspoCRM Contributor License Agreement v1.0.
+
+2020-03-17
+
+Peter Liubko

--- a/contributors/unitorzero.md
+++ b/contributors/unitorzero.md
@@ -1,5 +1,0 @@
-I hereby agree to the terms of the EspoCRM Contributor License Agreement v1.0.
-
-2020-03-17
-
-Peter Liubko


### PR DESCRIPTION
**skip Rebuild** is a flag in the file `entity Defs/{Entity Name}.json` for indicate Entity that do NOT need to be rebuild when CRM will rebuilds.
Possible cases:
  - the need to do rebuild for the entire CRM without touching individual Entities (tables);
  - creating a DB-side view for Entity content;