### PR TITLE
add missing `use` in settings.php service

### DIFF
--- a/application/Espo/Services/Settings.php
+++ b/application/Espo/Services/Settings.php
@@ -30,7 +30,7 @@
 namespace Espo\Services;
 
 use Espo\Core\Exceptions\Forbidden;
-use Espo\Core\Exceptions\NotFound;
+use Espo\Core\Exceptions\Error;
 use Espo\Core\Exceptions\BadRequest;
 
 use Espo\ORM\Entity;


### PR DESCRIPTION
Someone was not able to see the error message "Permission denied".