### PR TITLE
Fix typo error for the word "unsubsribe" (previously: "unsubsbribe")

### DIFF
--- a/application/Espo/Resources/i18n/bg_BG/EmailTemplate.json
+++ b/application/Espo/Resources/i18n/bg_BG/EmailTemplate.json
@@ -20,7 +20,7 @@
     "actual": "действителен"
   },
   "messages": {
-    "infoText": "Предлагани заместители: {optOutUrl} & # 8211; URL за unsubsbribe връзка; {OptOutLink} & # 8211; за връзка за отписване."
+    "infoText": "Предлагани заместители: {optOutUrl} & # 8211; URL за unsubscribe връзка; {OptOutLink} & # 8211; за връзка за отписване."
   },
   "placeholderTexts": {
     "optOutUrl": "URL за unsubsbribe връзка",

--- a/application/Espo/Resources/i18n/en_US/EmailTemplate.json
+++ b/application/Espo/Resources/i18n/en_US/EmailTemplate.json
@@ -19,7 +19,7 @@
         "Available placeholders": "Available placeholders"
     },
     "messages": {
-        "infoText": "Available placeholders:\n\n{optOutUrl} &#8211; URL for an unsubsbribe link;\n\n{optOutLink} &#8211; an unsubscribe link."
+        "infoText": "Available placeholders:\n\n{optOutUrl} &#8211; URL for an unsubscribe link;\n\n{optOutLink} &#8211; an unsubscribe link."
     },
     "tooltips": {
         "oneOff": "Check if you are going to use this template only once. E.g. for Mass Email."

--- a/application/Espo/Resources/i18n/fa_IR/EmailTemplate.json
+++ b/application/Espo/Resources/i18n/fa_IR/EmailTemplate.json
@@ -21,7 +21,7 @@
     "actual": "واقعی"
   },
   "messages": {
-    "infoText": "متغیرهایی موجود:\n\n{optOutUrl} - URL برای یک لینک unsubsbribe؛\n\n{optOutLink} - یک لینک لغو اشتراک"
+    "infoText": "متغیرهایی موجود:\n\n{optOutUrl} - URL برای یک لینک unsubscribe؛\n\n{optOutLink} - یک لینک لغو اشتراک"
   },
   "placeholderTexts": {
     "optOutUrl": "نشانی اینترنتی برای پیوند لغو اشتراک"

--- a/application/Espo/Resources/i18n/lt_LT/EmailTemplate.json
+++ b/application/Espo/Resources/i18n/lt_LT/EmailTemplate.json
@@ -22,7 +22,7 @@
     "actual": "Esamas"
   },
   "messages": {
-    "infoText": "Galimi užpildai:\n\n{optOutUrl} & # 8211; \"Unsubsbribe\" nuorodos URL;\n\n{optOutLink} & # 8211; Atsisakyti prenumeratos nuorodą."
+    "infoText": "Galimi užpildai:\n\n{optOutUrl} & # 8211; \"Unsubscribe\" nuorodos URL;\n\n{optOutLink} & # 8211; Atsisakyti prenumeratos nuorodą."
   },
   "placeholderTexts": {
     "optOutUrl": "URL nepasirinkto šlamšto nuorodos",

--- a/application/Espo/Resources/i18n/nl_NL/EmailTemplate.json
+++ b/application/Espo/Resources/i18n/nl_NL/EmailTemplate.json
@@ -18,7 +18,7 @@
     "actual": "huidig"
   },
   "messages": {
-    "infoText": "Beschikbare tijdelijke aanduidingen:\n\n{optOutUrl} & # 8211; URL voor een unsubsbribe-link;\n\n{optOutLink} & # 8211; een afmeldlink."
+    "infoText": "Beschikbare tijdelijke aanduidingen:\n\n{optOutUrl} & # 8211; URL voor een unsubscribe-link;\n\n{optOutLink} & # 8211; een afmeldlink."
   },
   "placeholderTexts": {
     "optOutUrl": "URL voor een uitschrijvingslink",


### PR DESCRIPTION
See: https://forum.espocrm.com/forum/bug-reports/62259-tipos-in-emailtemplate-create