### PR TITLE
edit-link-modal: keep elements positions

### DIFF
--- a/client/src/views/admin/link-manager/modals/edit.js
+++ b/client/src/views/admin/link-manager/modals/edit.js
@@ -503,7 +503,7 @@ define('views/admin/link-manager/modals/edit',
             if (view) {
                 view.disabled = true;
             }
-            this.$el.find('.cell[data-name=' + name+']').addClass('hidden');
+            this.$el.find('.cell[data-name=' + name+']').children().hide();
         },
 
         showField: function (name) {
@@ -511,7 +511,7 @@ define('views/admin/link-manager/modals/edit',
             if (view) {
                 view.disabled = false;
             }
-            this.$el.find('.cell[data-name=' + name+']').removeClass('hidden');
+            this.$el.find('.cell[data-name=' + name+']').children().show();
         },
 
         handleLinkTypeChange: function () {


### PR DESCRIPTION
Hi @yurikuzn 

I hope this is helpful, because in recent versions the edit links modal elements not keeping the same position, so that may cause confusion for the user

<img width="902" alt="Screen Shot 2020-09-08 at 5 07 37 PM" src="https://user-images.githubusercontent.com/2862528/92487558-0c5ea700-f1f6-11ea-9660-7725ca22c7ad.png">
<img width="899" alt="Screen Shot 2020-09-08 at 5 08 44 PM" src="https://user-images.githubusercontent.com/2862528/92487566-0f599780-f1f6-11ea-8abd-fe2056e4490d.png">

Best Regards

