### PR TITLE
Fields ACL: additional way to define it directly from field manager

### DIFF
--- a/application/Espo/Core/Acl/GlobalRestricton.php
+++ b/application/Espo/Core/Acl/GlobalRestricton.php
@@ -144,6 +144,22 @@ class GlobalRestricton
                 $scopeData->fields->$type = $resultFieldList;
                 $scopeData->attributes->$type = $resultAttributeList;
             }
+
+            foreach ($fieldList as $field) {
+                $fieldAcl = $this->metadata->get(['entityDefs', $scope, 'fields', $field, 'acl']) ?? [];
+
+                foreach ($this->fieldTypeList as $type) {
+                    if ($fieldAcl[$type] === true) {
+                        $isNotEmpty = true;
+                        $scopeData->fields->$type[] = $field;
+                        $fieldAttributeList = $this->fieldUtil->getAttributeList($scope, $field);
+                        foreach ($fieldAttributeList as $attribute) {
+                            $scopeData->attributes->$type[] = $attribute;
+                        }
+                    }
+                }
+            }
+
             foreach ($this->linkTypeList as $type) {
                 $resultLinkList = [];
 


### PR DESCRIPTION
Hi @yurikuzn 

This is about an additional way to control fields access directly from the entity defs, in additions to the existing `entityACL` metadata.

This is more easy for developers to define the ACL for new type fields or existing fields, and even can be set from field manager in the future.

Example:
[This ACL here](https://github.com/espocrm/espocrm/blob/master/application/Espo/Resources/metadata/entityAcl/User.json#L4):
<img width="583" alt="Screen Shot 2020-10-01 at 2 48 47 PM" src="https://user-images.githubusercontent.com/2862528/94805553-3bcb9280-03f5-11eb-9df9-9dfc37abcfe9.png">

can be set as following from the entityDefs:
<img width="658" alt="Screen Shot 2020-10-01 at 2 45 37 PM" src="https://user-images.githubusercontent.com/2862528/94805268-c8c21c00-03f4-11eb-96c1-e4ecebe2a8fb.png">

If you liked the idea and stuck with minor code issues would like to tell me to update ;)
