### PR TITLE
Sanity check for Tester.saveTestConfigData

### DIFF
--- a/tests/integration/Core/Tester.php
+++ b/tests/integration/Core/Tester.php
@@ -146,7 +146,8 @@ class Tester
     {
         $configData = $this->getTestConfigData();
 
-        if ($configData[$optionName] === $data) {
+        if (array_key_exists($optionName, $configData)
+            && $configData[$optionName] === $data) {
             return true;
         }
 


### PR DESCRIPTION
Currently the method assumes keys exist in the test config.php which
is not the case when you have setup the environment [following the documentation](https://docs.espocrm.com/development/tests/).

A new bare `tests/integration/config.php` will only have the `database` key set, though the current implementation expects other keys, the firts to fail is `lastModifiedTime` which is save during the setup of the test environment.

With the current code everytest fails:

```
espocrm/tests/integration/Core/Tester.php:149
espocrm/tests/integration/Core/Tester.php:311
espocrm/tests/integration/Core/Tester.php:268
espocrm/tests/integration/Core/Tester.php:219
espocrm/tests/integration/Core/BaseTestCase.php:140

121) tests\integration\Espo\Webhook\AclTest::testApiUserNoAccess1
Undefined index: lastModifiedTime
```

This commit simply adds a sanity check of `array_key_exists` which ensures the key is there before trying the comparison.

I am on PHP 7.4.11, macOS