### PR TITLE
fix autoload path merging

### DIFF
--- a/application/Espo/Core/Utils/Autoload.php
+++ b/application/Espo/Core/Utils/Autoload.php
@@ -108,10 +108,10 @@ class Autoload
         foreach ($this->metadata->getModuleList() as $moduleName) {
             $modulePath = str_replace('{*}', $moduleName, $this->paths['modulePath']);
 
-            $data = array_merge($data, $this->loadData($modulePath));
+            $data = array_merge_recursive($data, $this->loadData($modulePath));
         }
 
-        $data = array_merge($data, $this->loadData($this->paths['customPath']));
+        $data = array_merge_recursive($data, $this->loadData($this->paths['customPath']));
 
         return $data;
     }


### PR DESCRIPTION
The pull request fixes the issue when there are multiple `autoload.json` files.

# Example:
**Module 1**
`application/Espo/Modules/Abc/Resources/autoload.json`
```json
{
    "autoloadFileList": [
        "application/Espo/Modules/Abc/vendor/autoload.php"
    ]
}
```
**Module 2**
`application/Espo/Modules/AutoloadIssueDemo/Resources/autoload.json`
```json
{
    "autoloadFileList": [
        "application/Espo/Modules/AutoloadIssueDemo/vendor/autoload.php"
    ]
}
```
**Module 3**
`application/Espo/Modules/Xyz/Resources/autoload.json`
```json
{
    "autoloadFileList": [
        "application/Espo/Modules/Xyz/vendor/autoload.php"
    ]
}
```

## Current result
`data/cache/application/autoload.php`
```php
<?php
return [
  'autoloadFileList' => [
    0 => 'application/Espo/Modules/Xyz/vendor/autoload.php'
  ]
];
```
## Expected result
`data/cache/application/autoload.php`
```php
<?php
return [
  'autoloadFileList' => [
    0 => 'application/Espo/Modules/Abc/vendor/autoload.php',
    1 => 'application/Espo/Modules/AutoloadIssueDemo/vendor/autoload.php',
    2 => 'application/Espo/Modules/Xyz/vendor/autoload.php'
  ]
];
```

## Extension demonstrating the issue
[autoload-issue-demo-0.0.1.zip](https://github.com/espocrm/espocrm/files/5754285/autoload-issue-demo-0.0.1.zip)
