### PR TITLE
link field keep name value in search mode

### DIFF
--- a/client/src/views/fields/link.js
+++ b/client/src/views/fields/link.js
@@ -366,7 +366,7 @@ define('views/fields/link', 'views/fields/base', function (Dep) {
                 }
 
                 $elementName.on('change', function () {
-                    if (!this.model.get(this.idName)) {
+                    if (this.mode !== 'search' && !this.model.get(this.idName)) {
                         $elementName.val(this.model.get(this.nameName));
                     }
                 }.bind(this));


### PR DESCRIPTION
Hi @yurikuzn ,

As I love using keyboard more than the mouse, I noticed that when we press enter, name-value is missing, so the user will not see the saved selected entity name any more.

This issue will not happpen if I clicked on the result item using the mouse, or if I used the select modal.

<img width="349" alt="Screen Shot 2021-01-05 at 9 21 11 PM" src="https://user-images.githubusercontent.com/2862528/103684011-fe4e4680-4f9b-11eb-886b-1ecf8c2ea6f6.png">
