### PR TITLE
Patch 15

### DIFF
--- a/client/src/views/record/list.js
+++ b/client/src/views/record/list.js
@@ -130,7 +130,7 @@ define('views/record/list', 'view', function (Dep) {
 
             'click .record-checkbox': function (e) {
                 var $target = $(e.currentTarget);
-                var id = $target.data('id');
+                var id = $target.data('id').toString();
                 if (e.currentTarget.checked) {
                     this.checkRecord(id, $target);
                 } else {


### PR DESCRIPTION
This fixed a bug that happens when the whole id chars are digits, 

The issue is as following:
- check "check all" checkbox
- uncheck a record that has "all-digits" id.
- mas actions will not exclode the unchecked id!!

My client was imported the data from anpther system, 