### PR TITLE
Feature: Adding Search filter reset button

### DIFF
--- a/client/res/templates/record/search.tpl
+++ b/client/res/templates/record/search.tpl
@@ -37,6 +37,8 @@
                 </button>
                 <button type="button" class="btn btn-text btn-icon-wide" data-action="reset" title="{{translate 'Reset'}}" style="visibility: hidden;">
                     <span class="fas fa-times"></span>
+                <button type="button" class="btn btn-text btn-icon-wide" data-action="refreshFilters" title="{{translate 'Reset Search Values'}}" style="visibility: hidden;">
+                    <span class="fas fa-redo-alt"></span>
                 </button>
                 <ul class="dropdown-menu pull-right filter-list">
                     <li class="dropdown-header">{{translate 'Add Field'}}</li>

--- a/client/src/views/record/search.js
+++ b/client/src/views/record/search.js
@@ -328,6 +328,9 @@ define('views/record/search', 'view', function (Dep) {
             'click button[data-action="refresh"]': function (e) {
                 this.refresh();
             },
+            'click button[data-action="refreshFilters"]': function (e) {
+                this.refreshFilters();
+            },
             'click a[data-action="selectPreset"]': function (e) {
                 var presetName = $(e.currentTarget).data('name') || null;
 
@@ -390,6 +393,7 @@ define('views/record/search', 'view', function (Dep) {
             this.manageLabels();
             this.handleLeftDropdownVisibility();
             this.controlResetButtonVisibility();
+            this.controlRefreshButtonVisibility();
 
             if (this.isSearchedWithAdvancedFilter) {
                 this.showResetFiltersButton();
@@ -420,7 +424,7 @@ define('views/record/search', 'view', function (Dep) {
 
             this.manageLabels();
             this.controlResetButtonVisibility();
-
+            this.controlRefreshButtonVisibility();
 
         },
 
@@ -476,6 +480,17 @@ define('views/record/search', 'view', function (Dep) {
             this.selectPreset(this.presetName, true);
 
             this.hideApplyFiltersButton();
+        },
+
+        refreshFilters: function () {
+            this.textFilter = '';
+            for (var valueIndex in this.advanced) {
+                this.advanced[valueIndex] = false;
+            }
+            this.trigger('reset');
+
+            this.collection.resetOrderToDefault();
+            this.selectPreset(this.presetName, false);
         },
 
         savePreset: function (name) {
@@ -572,6 +587,7 @@ define('views/record/search', 'view', function (Dep) {
         	this.$filtersButton = this.$el.find('.search-row button.filters-button');
             this.$leftDropdown = this.$el.find('div.search-row div.left-dropdown');
             this.$resetButton = this.$el.find('[data-action="reset"]');
+            this.$refreshButton = this.$el.find('[data-action="refreshFilters"]');
             this.$applyFiltersContainer = this.$el.find('.advanced-filters-apply-container');
 
             this.updateAddFilterButton();
@@ -581,6 +597,7 @@ define('views/record/search', 'view', function (Dep) {
             this.manageLabels();
 
             this.controlResetButtonVisibility();
+            this.controlRefreshButtonVisibility();
         },
 
         manageLabels: function () {
@@ -627,6 +644,42 @@ define('views/record/search', 'view', function (Dep) {
                 $resetButton.css('visibility', 'visible');
             } else {
                 $resetButton.css('visibility', 'hidden');
+            }
+        },
+
+         controlRefreshButtonVisibility: function () {
+            var presetName = this.presetName || null;
+            var primary = this.primary;
+
+            var $refreshButton = this.$refreshButton;
+
+            var toShow = false;
+
+            if (this.textFilter) {
+                toShow = true;
+            } else {
+                if (presetName && presetName != primary) {
+
+                } else {
+                    if (Object.keys(this.advanced).length) {
+                        toShow = true;
+                    }
+                }
+            }
+
+            if (!toShow) {
+                if (
+                    this.collection.orderBy !== this.collection.defaultOrderBy ||
+                    this.collection.order !== this.collection.defaultOrder
+                ) {
+                    toShow = true;
+                }
+            }
+
+            if (toShow) {
+                $refreshButton.css('visibility', 'visible');
+            } else {
+                $refreshButton.css('visibility', 'hidden');
             }
         },
 
@@ -683,7 +736,6 @@ define('views/record/search', 'view', function (Dep) {
                 if (primary) {
                 	var label = this.translate(primary, 'presetFilters', this.entityType);
                 	var style = this.getPrimaryFilterStyle();
-
                 	filterLabel = label;
                 	filterStyle = style;
                 }
@@ -718,6 +770,7 @@ define('views/record/search', 'view', function (Dep) {
             this.updateSearch();
             this.updateCollection();
             this.controlResetButtonVisibility();
+            this.controlRefreshButtonVisibility();
 
             this.isSearchedWithAdvancedFilter = this.hasAdvancedFilter();
         },


### PR DESCRIPTION
This is a very small feature to reset the advanced filter values.

- When there is an advanced filter set in the list view even after the refresh of the tab or back to the same page will never erase the value that is added in the advanced filter input text box.
- It is annoying to remove the value from the text box and re-enter the next value to be searched.
- So, a small button similar to the reset button added next to the reset button.
-  The visibility of the button and the on-click actions are handled.

Related discussion in espocrm forum is [here](https://forum.espocrm.com/forum/developer-help/70737-how-to-customize-the-search-js?p=70767#post70767)