### PR TITLE
fix labels vertical gaps

### DIFF
--- a/frontend/less/espo/elements/type.less
+++ b/frontend/less/espo/elements/type.less
@@ -135,6 +135,7 @@ blockquote {
 .label-md {
     font-weight: normal;
     font-size: 100%;
+    line-height: 1.9;
     padding: @label-padding-medium;
     top: 0;
 }


### PR DESCRIPTION
## After
<img width="410" alt="Screen Shot 2021-06-02 at 18 16 16" src="https://user-images.githubusercontent.com/2862528/120507149-392f9b80-c3cf-11eb-8291-e35908340a31.png">

## Before
<img width="421" alt="Screen Shot 2021-06-02 at 18 16 43" src="https://user-images.githubusercontent.com/2862528/120507154-3af95f00-c3cf-11eb-92be-1b5eec535327.png">
