### PR TITLE
fix css

### DIFF
--- a/frontend/less/espo/misc/timeline/timeline.less
+++ b/frontend/less/espo/misc/timeline/timeline.less
@@ -78,7 +78,7 @@
 }
 
 .vis-item.vis-background.busy {
-    background-color: @gray-lighter;
+    background-color: @main-gray;
 }
 
 .vis-item.vis-background.event-range {


### PR DESCRIPTION
Busy events are not being displayed in the Scheduler panel using Sakura or Violet theme variants.

### Before:

![image](https://user-images.githubusercontent.com/17282224/133505009-c64c9574-f055-4391-983f-dc23c4261d12.png)

### After:

**Classic Espo**

![image](https://user-images.githubusercontent.com/17282224/133506216-2d3bac84-dc17-4323-907a-ec6ec77df71e.png)

**Classic Hazyblue**

![image](https://user-images.githubusercontent.com/17282224/133506328-9d649ca7-b6f4-44b0-b9a4-db58fb33683e.png)

**Classic Sakura**

![image](https://user-images.githubusercontent.com/17282224/133506392-08eaa09b-a2a8-480c-8f36-2f8b34b81f82.png)

**Classic Violet**

![image](https://user-images.githubusercontent.com/17282224/133506437-de8947d0-1e11-48bb-99be-5da9413a9ff4.png)
