### PR TITLE
improve field manager quick search

### DIFF
--- a/client/src/views/admin/field-manager/list.js
+++ b/client/src/views/admin/field-manager/list.js
@@ -140,8 +140,8 @@ define('views/admin/field-manager/list', 'view', function (Dep) {
                 let matched = false;
 
                 if (
-                    item.label.toLowerCase().indexOf(lowerCaseText) === 0 ||
-                    item.name.toLowerCase().indexOf(lowerCaseText) === 0
+                    item.label.toLowerCase().indexOf(lowerCaseText) !== -1 ||
+                    item.name.toLowerCase().indexOf(lowerCaseText) !== -1
                 ) {
                     matched = true;
                 }


### PR DESCRIPTION
to search over all places not only starting, I also tried this code and works fine:

```
                if (
                    item.label.toLowerCase().indexOf(lowerCaseText) === 0 ||
                    item.name.toLowerCase().indexOf(lowerCaseText) === 0 ||
                    (
                        lowerCaseText.length > 1 && (
                            item.label.toLowerCase().indexOf(lowerCaseText) !== -1 ||
                            item.name.toLowerCase().indexOf(lowerCaseText) !== -1
                        )
                    )
                ) {
                    matched = true;
                }

```