### PR TITLE
Handles page offset when on last page

### DIFF
--- a/client/src/collection.js
+++ b/client/src/collection.js
@@ -122,6 +122,11 @@ define('collection', [], function () {
 
         lastPage: function () {
             let offset = this.total - this.total % this.maxSize;
+            
+            // handle last page if remainder of last page is 0
+            if (offset === this.total) {
+                offset = this.total - this.maxSize
+            }
 
             this.setOffset(offset);
         },


### PR DESCRIPTION
Fixes #2130

By devscrew:

last option in pagination doesn't show records when total % maxSize return 0,
e.g in list view there are 20 records and you set max row size as 10 to display in listview, so offset for last page will be 20,

REF: https://forum.espocrm.com/forum/feature-requests/8146-pagination-instead-of-show-more?p=76221#post76221