### PR TITLE
fix folder name

### DIFF
--- a/application/Espo/Services/EmailAccount.php
+++ b/application/Espo/Services/EmailAccount.php
@@ -377,7 +377,7 @@ class EmailAccount extends Record implements
         }
 
         foreach ($monitoredFolders as $folder) {
-            $folder = mb_convert_encoding(trim($folder), 'UTF7-IMAP', 'UTF-8');
+            $folder = mb_convert_encoding($folder, 'UTF7-IMAP', 'UTF-8');
 
             $portionLimit = $this->getConfig()->get('personalEmailMaxPortionSize', self::PORTION_LIMIT);
 

--- a/application/Espo/Services/InboundEmail.php
+++ b/application/Espo/Services/InboundEmail.php
@@ -268,7 +268,7 @@ class InboundEmail extends RecordService implements
         }
 
         foreach ($monitoredFolders as $folder) {
-            $folder = mb_convert_encoding(trim($folder), 'UTF7-IMAP', 'UTF-8');
+            $folder = mb_convert_encoding($folder, 'UTF7-IMAP', 'UTF-8');
 
             $portionLimit = $this->config->get('inboundEmailMaxPortionSize', self::PORTION_LIMIT);
 


### PR DESCRIPTION
Sometimes folders will have trailing spaces and this will lead to the following error:

ERROR: EmailAccount xxxxxxx (Select Folder) [0] cannot change folder, maybe it does not exist [] []
