### PR TITLE
Fixed max collection size

### DIFF
--- a/application/Espo/Core/Record/SearchParamsFetcher.php
+++ b/application/Espo/Core/Record/SearchParamsFetcher.php
@@ -228,6 +228,10 @@ class SearchParamsFetcher
             $params['maxSize'] = $limit;
         }
 
+        if ($value < 1) {
+            throw new Forbidden('Max size must be greater than 0.');
+        }
+
         if ($value > $limit) {
             throw new Forbidden(
                 "Max size should not exceed " . $limit . ". Use offset and limit."


### PR DESCRIPTION
Prevented users from fetching full-size collection by setting `maxSize` as 0. (e.g. `/api/v1/Quote/action/list?maxSize=0`.)

Setting negative `maxSize` now also causes 403 error instead of 500.