### PR TITLE
Shift select implementation

### DIFF
--- a/client/src/views/record/list.js
+++ b/client/src/views/record/list.js
@@ -512,13 +512,7 @@ function (Dep, MassActionHelper, ExportHelper) {
             'click .record-checkbox': function (e) {
                 const $target = $(e.currentTarget);
 
-                if (!this._lastChecked) {
-                    this._lastChecked = $target;
-
-                    return;
-                }
-
-                if (e.shiftKey) {
+                if (e.shiftKey && this._lastChecked) {
                     const $checkboxes = this.$el.find('input.record-checkbox');
                     const start = $checkboxes.index($target);
                     const end = $checkboxes.index(this._lastChecked);

--- a/client/src/views/record/list.js
+++ b/client/src/views/record/list.js
@@ -422,6 +422,11 @@ function (Dep, MassActionHelper, ExportHelper) {
         noDataDisabled: false,
 
         /**
+         * @private
+         */
+        _lastChecked: null,
+
+        /**
          * @inheritDoc
          */
         events: {
@@ -505,15 +510,31 @@ function (Dep, MassActionHelper, ExportHelper) {
              * @this module:views/record/list.Class
              */
             'click .record-checkbox': function (e) {
-                let $target = $(e.currentTarget);
+                const $target = $(e.currentTarget);
 
-                let id = $target.attr('data-id');
+                if (!this._lastChecked) {
+                    this._lastChecked = $target;
 
-                if (e.currentTarget.checked) {
-                    this.checkRecord(id, $target);
-                } else {
-                    this.uncheckRecord(id, $target);
+                    return;
                 }
+
+                if (e.shiftKey) {
+                    const $checkboxes = this.$el.find('input.record-checkbox');
+                    const start = $checkboxes.index($target);
+                    const end = $checkboxes.index(this._lastChecked);
+                    const checked = this._lastChecked.prop('checked');
+
+                    $checkboxes.slice(Math.min(start, end), Math.max(start, end) + 1).each((i, el) => {
+                        const $el = $(el);
+
+                        $el.prop('checked', checked);
+                        this.checkboxClick($el, checked);
+                    });
+                } else {
+                    this.checkboxClick($target, $target.is(':checked'));
+                }
+
+                this._lastChecked = $target;
             },
             /**
              * @param {JQueryKeyEventObject} e
@@ -559,6 +580,23 @@ function (Dep, MassActionHelper, ExportHelper) {
             'click a.reset-custom-order': function () {
                 this.resetCustomOrder();
             },
+        },
+
+        /**
+         * 
+         * @param {JQuery} $checkbox 
+         * @param {boolean} checked 
+         * 
+         * @private
+         */
+        checkboxClick: function ($checkbox, checked) {
+            const id = $checkbox.attr('data-id');
+
+            if (checked) {
+                this.checkRecord(id, $checkbox);
+            } else {
+                this.uncheckRecord(id, $checkbox);
+            }
         },
 
         resetCustomOrder: function () {


### PR DESCRIPTION
Allow user to select multiple records in `record/list` view by holding `Shift` key.