### PR TITLE
Call `loadListAdditionalFields` on record service

### DIFF
--- a/application/Espo/Core/Record/Service.php
+++ b/application/Espo/Core/Record/Service.php
@@ -1036,7 +1036,7 @@ class Service implements Crud,
             ->find();
 
         foreach ($collection as $itemEntity) {
-            $this->loadListAdditionalFields($itemEntity, $preparedSearchParams);
+            $recordService->loadListAdditionalFields($itemEntity, $preparedSearchParams);
 
             $recordService->prepareEntityForOutput($itemEntity);
         }


### PR DESCRIPTION
Shouldn't `loadListAdditionalFields` method be called on the record service of the related entity?

This will not affect Field Processing, since List Load Processor loads classes based on `$entity->getEntityType()` . However in many cases developers might want to extend `loadListAdditionalFields`.