### PR TITLE
Backbone model change fix

### DIFF
--- a/client/src/views/fields/base.js
+++ b/client/src/views/fields/base.js
@@ -840,7 +840,7 @@ define('views/fields/base', ['view'], function (Dep) {
                 });
 
                 this.listenTo(this, 'change', () => {
-                    var attributes = this.fetch();
+                    const attributes = Espo.Utils.deepClone(this.fetch());
 
                     this.model.set(attributes, {ui: true});
                 });

--- a/client/src/views/fields/base.js
+++ b/client/src/views/fields/base.js
@@ -840,7 +840,7 @@ define('views/fields/base', ['view'], function (Dep) {
                 });
 
                 this.listenTo(this, 'change', () => {
-                    const attributes = Espo.Utils.deepClone(this.fetch());
+                    const attributes = Espo.Utils.cloneDeep(this.fetch());
 
                     this.model.set(attributes, {ui: true});
                 });

--- a/client/src/views/fields/base.js
+++ b/client/src/views/fields/base.js
@@ -840,7 +840,7 @@ define('views/fields/base', ['view'], function (Dep) {
                 });
 
                 this.listenTo(this, 'change', () => {
-                    const attributes = Espo.Utils.cloneDeep(this.fetch());
+                    const attributes = this.fetch();
 
                     this.model.set(attributes, {ui: true});
                 });

--- a/client/src/views/fields/link-multiple.js
+++ b/client/src/views/fields/link-multiple.js
@@ -770,8 +770,8 @@ define('views/fields/link-multiple', ['views/fields/base', 'helpers/record-modal
         fetch: function () {
             let data = {};
 
-            data[this.idsName] = this.ids;
-            data[this.nameHashName] = this.nameHash;
+            data[this.idsName] = Espo.Utils.cloneDeep(this.ids);
+            data[this.nameHashName] = Espo.Utils.cloneDeep(this.nameHash);
 
             return data;
         },


### PR DESCRIPTION
Model `set` method's first parameter shouldn't  be passed by reference, as it could cause a lot of very hard to debug and unexpected behaviour. E.g. because of how the changes are detected in the Backbone library, passing by reference causes Backbone not to detect attribute changes, thus `change` event is not called. 

Practical example of the bug:

- Create about 10 different teams with positions.
- In the link multiple field with roles at the user detail select all ten teams at once.
- Position column won't render.

Cause: Link multiple field is set by reference => change event won't get fired => `loadRoleList` won't get called.