### PR TITLE
added other reserved keywords

### DIFF
--- a/application/Espo/Tools/EntityManager/NameUtil.php
+++ b/application/Espo/Tools/EntityManager/NameUtil.php
@@ -56,6 +56,8 @@ class NameUtil
         'insteadof', 'interface', 'isset', 'list', 'namespace', 'new', 'or', 'print', 'private',
         'protected', 'public', 'require', 'require_once', 'return', 'static', 'switch', 'throw',
         'trait', 'try', 'unset', 'use', 'var', 'while', 'xor', 'common', 'fn', 'parent',
+        'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void', 'iterable', 'object',
+        'mixed', 'never',
     ];
 
     /**


### PR DESCRIPTION
Recently a colleague of mine created an entity called "Object" and accidentaly killed the app.

The list of other reserved keywords: https://www.php.net/manual/en/reserved.other-reserved-words.php