### PR TITLE
Fixed requirePromise in fix branch

### DIFF
--- a/client/src/loader.js
+++ b/client/src/loader.js
@@ -766,7 +766,7 @@
             return new Promise((resolve, reject) => {
                 this.require(
                     subject,
-                    () => resolve(),
+                    (...args) => resolve(...args),
                     () => reject()
                 );
             });


### PR DESCRIPTION
Add `requirePromise` fix to *fix* branch, because the method is already published and it doesn't have much use, as it doesn't pass the loaded dependencies. 

The fix cannot even potentially break any existing Espo instance.