### PR TITLE
Regex with optional capture groups might cause catastrophic backtracking

### DIFF
--- a/application/Espo/Core/Api/ErrorOutput.php
+++ b/application/Espo/Core/Api/ErrorOutput.php
@@ -215,8 +215,7 @@ class ErrorOutput
 
     private function clearPasswords(string $string): string
     {
-        /** @var string */
-        return preg_replace('/"(.*?password.*?)":".*?"/i', '"$1":"*****"', $string);
+        return preg_replace('/"(.*?password.*?)":".*?"/i', '"$1":"*****"', $string) ?? $string;
     }
 
     private static function generateErrorBody(string $header, string $text): string

--- a/application/Espo/Core/Api/ErrorOutput.php
+++ b/application/Espo/Core/Api/ErrorOutput.php
@@ -215,7 +215,7 @@ class ErrorOutput
 
     private function clearPasswords(string $string): string
     {
-        return preg_replace('/"(.*?password.*?)":".*?"/i', '"$1":"*****"', $string) ?? $string;
+        return preg_replace('/"(.*password.*)":".*"/i', '"$1":"*****"', $string) ?? $string;
     }
 
     private static function generateErrorBody(string $header, string $text): string


### PR DESCRIPTION
I noticed that when I uplaod large zip files, sometimes, the app returns error 500, instead of normal error output. 

I found out that the error is due to the [catasthropic backgracing](https://www.regular-expressions.info/catastrophic.html) which is not unusual with regex expressions containing lot of optional capture groups. The error causes `preg_replace` to return `null`, causing error since return value doesn't match. 