### PR TITLE
css fix

### DIFF
--- a/frontend/less/espo/custom.less
+++ b/frontend/less/espo/custom.less
@@ -3659,7 +3659,7 @@ a.close:hover {
 }
 
 .input-group-currency {
-    table-layout: fixed;
+    table-layout: auto;
     width: 100%;
 
     > .input-group-item:last-child {


### PR DESCRIPTION
When 25% < 80px, the currency field overflows. Since table-cells don't support min-width (min and max widths have undefined behaviour on tables since CSS 2.1), this can be resolved in one of two following ways:
- Remove the table layout and style the inputs using inline-block.
- Change table layout to `auto` and let the browser fix the overflowing width.

![image](https://user-images.githubusercontent.com/44263817/202851100-aeb25c20-9348-4147-b4b6-fc6f07e95768.png)
