### PR TITLE
getColumns datatype fix

### DIFF
--- a/application/Espo/ORM/Mapper/BaseMapper.php
+++ b/application/Espo/ORM/Mapper/BaseMapper.php
@@ -684,7 +684,7 @@ class BaseMapper implements RDBMapper
             }
 
             if ($columnType == Entity::FLOAT) {
-                return (int) $value;
+                return (float) $value;
             }
 
             return $value;


### PR DESCRIPTION
The bug made `RDBRelation::getColumn` always floor value to int. 