### PR TITLE
Added support for global mass actions defs

### DIFF
--- a/client/src/views/record/list.js
+++ b/client/src/views/record/list.js
@@ -1186,7 +1186,7 @@ function (Dep, MassActionHelper, ExportHelper, RecordModal) {
          * @param {string} name An action.
          */
         massAction: function (name) {
-            let defs = this.getMetadata().get(['clientDefs', this.scope, 'massActionDefs', name]) || {};
+            let defs = this.massActionDefs[name] || {};
 
             let handler = defs.handler;
 
@@ -1242,18 +1242,15 @@ function (Dep, MassActionHelper, ExportHelper, RecordModal) {
 
                 data.entityType = this.entityType;
 
-                let waitMessage = this.getMetadata()
-                    .get(['clientDefs', this.scope, 'massActionDefs', name, 'waitMessage']) || 'pleaseWait';
+                let waitMessage = defs.waitMessage || 'pleaseWait';
 
                 Espo.Ui.notify(this.translate(waitMessage, 'messages', this.scope));
 
-                let url = this.getMetadata().get(['clientDefs', this.scope, 'massActionDefs', name, 'url']);
+                let url = defs.url;
 
                 Espo.Ajax.postRequest(url, data)
                     .then(result=> {
-                        let successMessage = result.successMessage ||
-                            this.getMetadata()
-                                .get(['clientDefs', this.scope, 'massActionDefs', name, 'successMessage']) || 'done';
+                        let successMessage = result.successMessage || defs.successMessage || 'done';
 
                         this.collection
                             .fetch()
@@ -1898,6 +1895,12 @@ function (Dep, MassActionHelper, ExportHelper, RecordModal) {
             ) {
                 this.removeMassAction('merge');
             }
+            
+            this.massActionDefs = _.extend(
+                {},
+                this.getMetadata().get(['clientDefs', 'Global', 'massActionDefs']) || {},
+                this.getMetadata().get(['clientDefs', this.scope, 'massActionDefs']) || {}
+            );
 
             let metadataMassActionList = (
                     this.getMetadata().get(['clientDefs', this.scope, 'massActionList']) || []
@@ -1906,7 +1909,7 @@ function (Dep, MassActionHelper, ExportHelper, RecordModal) {
                 );
 
             metadataMassActionList.forEach(item => {
-                let defs = this.getMetadata().get(['clientDefs', this.scope, 'massActionDefs', item]) || {};
+                let defs = this.massActionDefs[item] || {};
 
                 if (!Espo.Utils.checkActionAvailability(this.getHelper(), defs)) {
                     return;
@@ -1941,8 +1944,7 @@ function (Dep, MassActionHelper, ExportHelper, RecordModal) {
                 }
 
                 if (~this.massActionList.indexOf(item)) {
-                    let defs = this.getMetadata()
-                        .get(['clientDefs', this.scope, 'massActionDefs', item]) || {};
+                    let defs = this.massActionDefs[item] || {};
 
                     if (!Espo.Utils.checkActionAvailability(this.getHelper(), defs)) {
                         return;
@@ -1959,8 +1961,7 @@ function (Dep, MassActionHelper, ExportHelper, RecordModal) {
             metadataMassActionList
                 .concat(metadataCheckAllMassActionList)
                 .forEach(action => {
-                    let defs = this.getMetadata()
-                           .get(['clientDefs', this.scope, 'massActionDefs', action]) || {};
+                    let defs = this.massActionDefs[action] || {};
 
                     if (!defs.initFunction || !defs.handler) {
                         return;


### PR DESCRIPTION
The list of mass actions is obtained from the global clientDefs, but the definitions are only obtained from the scope clientDefs, making it impossible to define global mass action with custom handler.