### PR TITLE
Fixed mime type in base64 string in ImageSourceProvider

### DIFF
--- a/application/Espo/Tools/Pdf/Dompdf/ImageSourceProvider.php
+++ b/application/Espo/Tools/Pdf/Dompdf/ImageSourceProvider.php
@@ -67,6 +67,6 @@ class ImageSourceProvider
 
         $contents = $this->fileStorageManager->getContents($attachment);
 
-        return 'data:image/' . $type . ';base64,' . base64_encode($contents);
+        return 'data:' . $type . ';base64,' . base64_encode($contents);
     }
 }


### PR DESCRIPTION
Mime type already contains "image/" prefix. Having it included twice won't affect PNGs and JPEGs, but fails for SVG images.