### PR TITLE
bug fix: tcpdf total page numbers for groups

### DIFF
--- a/application/Espo/Tools/Pdf/Tcpdf/Tcpdf.php
+++ b/application/Espo/Tools/Pdf/Tcpdf/Tcpdf.php
@@ -128,20 +128,7 @@ class Tcpdf extends TcpdfOriginal
 
         $html = $this->headerHtml;
 
-        if ($this->useGroupNumbers) {
-            $html = str_replace('{pageNumber}', '{{:png:}}', $html);
-            $html = str_replace('{pageAbsoluteNumber}', '{{:pnp:}}', $html);
-        } else {
-            $html = str_replace('{pageNumber}', '{{:pnp:}}', $html);
-            $html = str_replace('{pageAbsoluteNumber}', '{{:pnp:}}', $html);
-        }
-
-        /** @phpstan-ignore-next-line */
-        if ($this->isUnicodeFont()) {
-            $html = str_replace('{totalPageNumber}', '{{:ptp:}}', $html);
-        } else {
-            $html = str_replace('{totalPageNumber}', '{:ptp:}', $html);
-        }
+        $html = $this->setPageNumbers($html);
 
         $this->writeHTMLCell(0, 0, '', '', $html, 0, 1, 0, '', 0, false);
     }
@@ -160,24 +147,41 @@ class Tcpdf extends TcpdfOriginal
 
         $html = $this->footerHtml;
 
-        if ($this->useGroupNumbers) {
-            $html = str_replace('{pageNumber}', '{{:png:}}', $html);
-            $html = str_replace('{pageAbsoluteNumber}', '{{:pnp:}}', $html);
-        } else {
-            $html = str_replace('{pageNumber}', '{{:pnp:}}', $html);
-            $html = str_replace('{pageAbsoluteNumber}', '{{:pnp:}}', $html);
-        }
-
-        /** @phpstan-ignore-next-line */
-        if ($this->isUnicodeFont()) {
-            $html = str_replace('{totalPageNumber}', '{{:ptp:}}', $html);
-        } else {
-            $html = str_replace('{totalPageNumber}', '{:ptp:}', $html);
-        }
+        $html = $this->setPageNumbers($html);
 
         $this->writeHTMLCell(0, 0, '', '', $html, 0, 1, 0, '', 0, false);
 
         $this->SetAutoPageBreak($autoPageBreak, $breakMargin);
+    }
+
+    /**
+     * @param string $html
+     * @return string
+     */
+    private function setPageNumbers($html): string {
+        if ($this->useGroupNumbers) {
+            $html = str_replace('{pageNumber}', '{{:png:}}', $html);
+            $html = str_replace('{pageAbsoluteNumber}', '{{:pnp:}}', $html);
+
+            /** @phpstan-ignore-next-line */
+            if ($this->isUnicodeFont()) {
+                $html = str_replace('{totalPageNumber}', '{{:ptg:}}', $html);
+            } else {
+                $html = str_replace('{totalPageNumber}', '{:ptg:}', $html);
+            }
+        } else {
+            $html = str_replace('{pageNumber}', '{{:pnp:}}', $html);
+            $html = str_replace('{pageAbsoluteNumber}', '{{:pnp:}}', $html);
+
+            /** @phpstan-ignore-next-line */
+            if ($this->isUnicodeFont()) {
+                $html = str_replace('{totalPageNumber}', '{{:ptp:}}', $html);
+            } else {
+                $html = str_replace('{totalPageNumber}', '{:ptp:}', $html);
+            }
+        }
+
+        return $html;
     }
 
     /**


### PR DESCRIPTION
The total page number was not correct for groups. The page number for a non-group was used, which produced the wrong result. The replaced value for the `totalPageNumber` placeholder in group mode has been changed from `ptp` to `ptg`. The `setPageNumbers` function has also been introduced to enhance code reuse.

Here is how the value of `totalPageNumber` changes as a result of the pull request:
```
Group   Page    Old   New
-----   ----    ---   ---
1       1       6     3
1       2       6     3
1       3       6     3
2       1       6     2
2       2       6     2
3       1       6     1
```
See [here](https://github.com/tecnickcom/TCPDF/blob/e3cffc9bcbc76e89e167e9eb0bbda0cab7518459/include/tcpdf_static.php#L72) for the TCPDF constant.