### PR TITLE
Fix inline edit close

### DIFF
--- a/client/src/views/fields/base.js
+++ b/client/src/views/fields/base.js
@@ -1278,7 +1278,7 @@ define('views/fields/base', ['view', 'ui/select'], function (Dep, /** module:ui/
             }
 
             if (!noReset) {
-                this.model.set(this.initialAttributes, {skipReRender: true});
+                this.model.set(this.initialAttributes);
             }
 
             let promise = this.setDetailMode()


### PR DESCRIPTION
Changing one field may cause other changes (e.g. via dynamic handler or dynamic logic) that are not reverted back to the UI when closing inline edit due to `skipReRender`. 

NOTE: This does not revert https://github.com/espocrm/espocrm/issues/2644 as `model.set` is executed before `setDetailMode` which is enough to avoid side effects described in the issue.