### PR TITLE
Order Extension by name

### DIFF
--- a/application/Espo/Resources/metadata/entityDefs/Extension.json
+++ b/application/Espo/Resources/metadata/entityDefs/Extension.json
@@ -53,7 +53,7 @@
         }
     },
     "collection": {
-        "orderBy": "createdAt",
-        "order": "desc"
+        "orderBy": "name",
+        "order": "asc"
     }
 }


### PR DESCRIPTION
Having extensions ordered by name makes it much faster to search in if you want to know whether a specific extension is installed.