### PR TITLE
Fix removing row from record/list

### DIFF
--- a/client/src/views/record/list.js
+++ b/client/src/views/record/list.js
@@ -3181,8 +3181,6 @@ function (Dep, MassActionHelper, ExportHelper, RecordModal) {
                 this.checkedList.splice(index, 1);
             }
 
-            this.removeRowHtml(id);
-
             let key = id;
 
             this.clearView(key);
@@ -3192,6 +3190,8 @@ function (Dep, MassActionHelper, ExportHelper, RecordModal) {
             if (~index) {
                 this.rowList.splice(index, 1);
             }
+
+            this.removeRowHtml(id);
         },
 
         /**


### PR DESCRIPTION
`removeRowHtml` might re-render the view, so it must come at the end of the function. Otherwise, it will try to re-render the last deleted row. This might cause error in console if the view manipulates DOM in after render.

**Step-by-step reproduction:**
1. Create a custom field that requires valid element in `afterRender`. Example:
```js
define('custom:views/test-abc/fields/name', ['views/fields/varchar'], function (Dep) {
    return Dep.extend({
        afterRender: function () {
            Dep.prototype.afterRender.call(this);

            console.log(this.$el.length); // expecting 1
        }
    });
});
```
2. Go to a list view with single record.
3. Remove the record.
![image](https://user-images.githubusercontent.com/44263817/225468218-a9dacad1-0fbe-4e09-a18e-db814e9f929b.png)

NOTE: An example of a view that throws an error if an element does not exist is e.g. edit mode of fields/int, where the AutoNumeric library requires a valid element.