### PR TITLE
border-radios fixes for rtl theme

### DIFF
--- a/frontend/less/espo-rtl/bootstrap-rtl/input-groups-rtl.less
+++ b/frontend/less/espo-rtl/bootstrap-rtl/input-groups-rtl.less
@@ -21,7 +21,7 @@
 .input-group-btn:first-child > .dropdown-toggle,
 .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle),
 .input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
-  .border-right-radius(@border-radius-base);
+  .border-right-radius(var(--border-radius));
   .border-left-radius(0);
 }
 .input-group-addon:first-child {

--- a/frontend/less/espo-rtl/custom.less
+++ b/frontend/less/espo-rtl/custom.less
@@ -356,17 +356,82 @@ table.table-admin-panel tr > td:first-child > div > a {
     padding-left: 10px;
 }
 
+.input-group > .input-group-btn:not(:first-child) > .btn:first-child {
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+    border-top-left-radius: var(--border-radius) !important;
+    border-bottom-left-radius: var(--border-radius) !important;
+}
+
+.input-group > .input-group-btn:last-child > .form-control:last-child {
+    border-top-left-radius: var(--border-radius) !important;
+    border-bottom-left-radius: var(--border-radius) !important;
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+}
+
+.field .input-group > .input-group-btn > button.btn.btn-icon:not(:last-child, .radius-right) {
+    border-radius: 0 !important;
+}
+
+.field .input-group > .input-group-btn > button.btn.btn-icon:last-child {
+    border-top-left-radius: 5px !important;
+    border-bottom-left-radius: 5px !important;
+}
+
+.field .input-group > input.main-element.form-control:first-child {
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+}
+
+.input-group > .input-group-item,
+.input-group {
+    > .selectize-control {
+        &.radius-right {
+            > .selectize-input {
+                border-top-left-radius: var(--border-radius);
+                border-bottom-left-radius: var(--border-radius);
+            }
+
+            &:not(.radius-left) {
+                > .selectize-input {
+                    border-top-right-radius: 0 !important;
+                    border-bottom-right-radius: 0 !important;
+                }
+            }
+        }
+
+        &.radius-left {
+            > .selectize-input {
+                border-top-right-radius: var(--border-radius);
+                border-bottom-right-radius: var(--border-radius);
+            }
+
+            &:not(.radius-right) {
+                > .selectize-input {
+                    border-top-left-radius: 0 !important;
+                    border-bottom-left-radius: 0 !important;
+                }
+            }
+        }
+    }
+}
+
 .btn {
     &.radius-right {
         border-top-left-radius: var(--border-radius) !important;
         border-bottom-left-radius: var(--border-radius) !important;
-        .border-right-radius(0) !important;
+        &:not(.radius-left) {
+            .border-right-radius(0) !important;
+        }
     }
 
     &.radius-left {
         border-top-right-radius: var(--border-radius) !important;
         border-bottom-right-radius: var(--border-radius) !important;
-        .border-left-radius(0) !important;
+        &:not(.radius-right) {
+            .border-left-radius(0) !important;
+        }
     }
 
     &.margin-right {

--- a/frontend/less/espo-rtl/custom.less
+++ b/frontend/less/espo-rtl/custom.less
@@ -360,11 +360,13 @@ table.table-admin-panel tr > td:first-child > div > a {
     &.radius-right {
         border-top-left-radius: var(--border-radius) !important;
         border-bottom-left-radius: var(--border-radius) !important;
+        .border-right-radius(0) !important;
     }
 
     &.radius-left {
         border-top-right-radius: var(--border-radius) !important;
         border-bottom-right-radius: var(--border-radius) !important;
+        .border-left-radius(0) !important;
     }
 
     &.margin-right {

--- a/frontend/less/espo-rtl/variables.less
+++ b/frontend/less/espo-rtl/variables.less
@@ -1,3 +1,3 @@
-@border-radius-value: 0;
+@border-radius-value: 5px;
 @panel-border-radius-value: 5px;
 @dropdown-border-radius-value: 3px;

--- a/frontend/less/espo/custom.less
+++ b/frontend/less/espo/custom.less
@@ -826,8 +826,6 @@ div.list-kanban > div > table {
 
 input.global-search-input {
     padding-right: 10px;
-    border-top-right-radius: var(--border-radius) !important;
-    border-bottom-right-radius: var(--border-radius) !important;
 }
 
 .global-search-button {

--- a/frontend/less/espo/layout-side.less
+++ b/frontend/less/espo/layout-side.less
@@ -753,8 +753,7 @@ body[data-navbar="side"] {
 
     @media screen and (min-width: @screen-sm-min) {
         input.global-search-input {
-            border-top-left-radius: 0 !important;
-            border-top-right-radius: 0 !important;
+            border-radius: 0 0 var(--border-radius) var(--border-radius) !important;
         }
 
         #global-search-panel {

--- a/frontend/less/espo/layout-top.less
+++ b/frontend/less/espo/layout-top.less
@@ -90,6 +90,10 @@ body:not([data-navbar="side"]) {
             }
         }
 
+        input.global-search-input {
+            border-radius: var(--border-radius) !important;
+        }
+
         .navbar-brand {
             padding: 0;
             width: @logo-width;


### PR DESCRIPTION
This is for help with enabling border radios for rtl themes, current behaviour is zero border radios whereas all other themes has it set to 5px witch looks better.

Before:
<img width="827" alt="Screenshot 2023-03-27 at 1 59 39 PM" src="https://user-images.githubusercontent.com/2862528/227923309-52dd7d31-98d2-4205-80a3-20599d85a247.png">
After:
<img width="827" alt="Screenshot 2023-03-27 at 1 58 50 PM" src="https://user-images.githubusercontent.com/2862528/227923363-5264bcbc-be4b-4fce-8b1c-185881d7eefa.png">
