### PR TITLE
Stream: Notes by portal users must always be public

### DIFF
--- a/application/Espo/Services/Note.php
+++ b/application/Espo/Services/Note.php
@@ -119,6 +119,10 @@ class Note extends Record
             throw new ForbiddenSilent("Only 'Post' type allowed.");
         }
 
+        if ($this->user->isPortal()) {
+            $entity->set('isInternal', false);
+        }
+
         if ($entity->isPost()) {
             $this->handlePostText($entity);
         }


### PR DESCRIPTION
If 'entityDefs.Note.fields.isInternal.default' is set to `true` then notes created by portal users are still being set to internal. The reason is the attribute `isInternal` is applied [client-side here](https://github.com/espocrm/espocrm/blob/stable/client/src/views/stream/panel.js#L236-L238), which is then being unset by [ACL Portal defs here](https://github.com/espocrm/espocrm/blob/stable/application/Espo/Resources/metadata/app/aclPortal.json#L83).

PR is my proposal on way to fix it.

Pull request is not addressing it, but still worth mentioning that [these lines of code](https://github.com/espocrm/espocrm/blob/stable/client/src/views/stream/panel.js#L184-L188) are redundant and could be changed to:

```js
this.allowInternalNotes = this.getMetadata().get(['clientDefs', this.scope, 'allowInternalNotes']) || false;
```