### PR TITLE
Fix: kanban dashlet scrolling

### DIFF
--- a/client/src/views/record/kanban.js
+++ b/client/src/views/record/kanban.js
@@ -399,9 +399,9 @@ define('views/record/kanban', ['views/record/list'], function (Dep) {
                     return;
                 }
 
-                let stickTop = this.$listKanban.position().top - topBarHeight;
+                let stickTop = this.$listKanban.offset().top - topBarHeight;
 
-                let edge = $middle.position().top + $middle.outerHeight(true);
+                let edge = $middle.offset().top + $middle.outerHeight(true);
                 let scrollTop = $window.scrollTop();
 
                 if (scrollTop < edge) {


### PR DESCRIPTION
When using the kanban dashlet, the kanban header sticks itself to the top of the page, if you have dashlets above the kanban one.

The position method actually returns the position relative to its first non-static parent. In the classic list kanban, .position().top and .offset().top happened to return the same thing.

Hopefully this doesn't break anything. 
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/48620541/236508820-01332ffa-ee5c-46ff-a868-a3eabde22ec6.png">
