### PR TITLE
Fixed count query with group by

### DIFF
--- a/application/Espo/ORM/Mapper/BaseMapper.php
+++ b/application/Espo/ORM/Mapper/BaseMapper.php
@@ -230,8 +230,7 @@ class BaseMapper implements RDBMapper
             ->build();
 
         $wrap = $aggregation === self::FUNC_COUNT && (
-            $select->isDistinct() ||
-            $select->getGroup() && $select->getHaving()
+            $select->isDistinct() || $select->getGroup()
         );
 
         if (!$wrap) {


### PR DESCRIPTION
Group by causes most of count queries to not work as result isn't properly aggregated. Every query with GROUP (independently of HAVING clause) needs wrapping into subquery.

This causes 1-N joins without implicit grouping to be unusable in appliers (as count query returns wrong count => pagination doesn't work).

Current workaround is to add always true having clause to queries, however I find this solution very hacky and inelegant.