### PR TITLE
edit-attributes.js fix missing translation label

### DIFF
--- a/client/src/views/admin/layouts/modals/edit-attributes.js
+++ b/client/src/views/admin/layouts/modals/edit-attributes.js
@@ -58,7 +58,7 @@ define('views/admin/layouts/modals/edit-attributes', ['views/modal', 'model'], f
                 },
                 {
                     name: 'cancel',
-                    text: 'Cancel',
+                    text: this.translate('Cancel'),
                 },
             ];
 


### PR DESCRIPTION
fix missing translation label for cancel button

Edit attributes modal was not using any translation for the "Cancel" button
![image](https://github.com/espocrm/espocrm/assets/32223252/3585ae94-86df-4318-8daa-68f598a9b6a0)
