### PR TITLE
Add title to list-tree-item to preview name

### DIFF
--- a/client/res/templates/record/list-tree-item.tpl
+++ b/client/res/templates/record/list-tree-item.tpl
@@ -16,7 +16,7 @@
     <span data-name="white-space" data-id="{{model.id}}" class="empty-icon{{#unless isEnd}} hidden{{/unless}}">&nbsp;</span>
 
     <a href="#{{model.name}}/view/{{model.id}}"
-        class="link{{#if isSelected}} text-bold{{/if}}" data-id="{{model.id}}"
+        class="link{{#if isSelected}} text-bold{{/if}}" data-id="{{model.id}}" title="{{name}}"
     >{{name}}</a>
 
     {{#unless readOnly}}


### PR DESCRIPTION
Hi Yuri,
Got this request from a client, I think it would be a good addition.

When a folder name is too long it will be almost impossible to read it, with this addition it will be possible to hover the mouse on the folder name to view it fully.

![vivaldi_2e4KgvC9w4](https://github.com/espocrm/espocrm/assets/32223252/0b9cb899-a090-40be-bcd8-fa93eafc5133)
