### PR TITLE
confirmAppRefresh on every app load with disabled cache

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -1097,7 +1097,7 @@ class App {
 
             if (
                 this.appTimestamp &&
-                appTimestamp !== this.appTimestamp &&
+                appTimestamp > this.appTimestamp &&
                 !bypassAppReload
             ) {
                 appTimestampChangeProcessed = true;


### PR DESCRIPTION
closes https://github.com/espocrm/espocrm/issues/2805

NOTE: Tested it. After refreshing the app, no modal popped-up. When I installed new extension, modal popped-up on all opened tabs, as expected.