### PR TITLE
Generate RFC 4122-compliant UUIDs

### DIFF
--- a/application/Espo/Core/Utils/Util.php
+++ b/application/Espo/Core/Utils/Util.php
@@ -638,7 +638,11 @@ class Util
     public static function generateUuid4(): string
     {
         try {
-            $hex = bin2hex(random_bytes(16));
+            $data = random_bytes(16);
+            $data[6] = chr(ord($data[6]) & 0x0f | 0x40);
+            $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
+
+            $hex = bin2hex($data);
         }
         catch (Exception) {
             throw new RuntimeException("Could not generate UUID.");


### PR DESCRIPTION
I've implemented the functionality to generate UUIDs compliant with [RFC 4122 - Section 4.4](https://www.rfc-editor.org/rfc/rfc4122#section-4.4) in this pull request.

### Before 

```
9515ab46-c857-212e-c001-aa98d4f1801c
              ^    ^
              1    2
```

### After

```
d6634a00-e304-4ea7-8c34-fe8710ffb055
              ^    ^
              1    2
d7a0ce95-d59c-4ddb-9169-26eb6634d861
              ^    ^
              1    2
4ca7c5da-53ee-497d-a178-9583f6e0cc0a
              ^    ^
              1    2
657af0c0-57f5-4047-b3e4-39d1c2e0e267
              ^    ^
              1    2
```
The digit at position 1 above is always "4" and the digit at position 2 is always one of "8", "9", "A" or "B".