### PR TITLE
Stream: Fixed UUID matching in `handlePostText` for notes

### DIFF
--- a/application/Espo/Services/Note.php
+++ b/application/Espo/Services/Note.php
@@ -216,7 +216,7 @@ class Note extends Record
         $siteUrl = $this->config->getSiteUrl();
 
         $regexp = '/' . preg_quote($siteUrl, '/') .
-            '(\/portal|\/portal\/[a-zA-Z0-9]*)?\/#([A-Z][a-zA-Z0-9]*)\/view\/([a-zA-Z0-9]*)/';
+            '(\/portal|\/portal\/[a-zA-Z0-9]*)?\/#([A-Z][a-zA-Z0-9]*)\/view\/([a-zA-Z0-9-]*)/';
 
         $post = preg_replace($regexp, '[\2/\3](#\2/view/\3)', $post);
 


### PR DESCRIPTION
Adjusted regex pattern by including a hyphen to correctly match UUIDs in URLs within the `handlePostText` method.

### Before

`[Case/159110f5](#Case/view/159110f5)-4ef6-22cb-b787-3fa1819ec4d4`
![image](https://github.com/espocrm/espocrm/assets/17282224/53ad9230-0cb1-492e-b385-586524f56f9c)

### After

![image](https://github.com/espocrm/espocrm/assets/17282224/96db830b-0247-4014-b7d4-e3583bd7e3c0)

