### PR TITLE
fix version check

### DIFF
--- a/application/Espo/Core/Upgrades/Actions/Base.php
+++ b/application/Espo/Core/Upgrades/Actions/Base.php
@@ -428,19 +428,19 @@ abstract class Base
                 $this->getLog()->error('SemVer: Version identification error: '.$e->getMessage().'.');
             }
 
-            if ($isInRange) {
-                return true;
+            if (!$isInRange) {
+                /** @var string $errorMessage */
+                $errorMessage = preg_replace('/\{version\}/', $currentVersion, $errorMessage);
+                /** @var string $errorMessage */
+                $errorMessage = preg_replace('/\{requiredVersion\}/', $version, $errorMessage);
+        
+                $this->throwErrorAndRemovePackage($errorMessage);
+        
+                return false;
             }
         }
 
-        /** @var string $errorMessage */
-        $errorMessage = preg_replace('/\{version\}/', $currentVersion, $errorMessage);
-        /** @var string $errorMessage */
-        $errorMessage = preg_replace('/\{requiredVersion\}/', $version, $errorMessage);
-
-        $this->throwErrorAndRemovePackage($errorMessage);
-
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Clients were able to upgrade their crm even though it should not .  

In my extension I set this:

    "acceptableVersions": [
        ">=7.0.8",
        "<=8.0.0"
    ],
