### PR TITLE
Add shared calendar options for agendaWeek and agendaDay

### DIFF
--- a/application/Espo/Modules/Crm/Resources/metadata/clientDefs/Calendar.json
+++ b/application/Espo/Modules/Crm/Resources/metadata/clientDefs/Calendar.json
@@ -7,7 +7,7 @@
     "scopeList": ["Meeting", "Call", "Task"],
     "allDayScopeList": ["Task"],
     "modeList": ["month", "agendaWeek", "timeline", "agendaDay"],
-    "sharedViewModeList": ["basicWeek", "month", "basicDay"],
+    "sharedViewModeList": ["basicWeek", "agendaWeek", "month", "basicDay", "agendaDay"],
     "additionalColorList": ["#AB78AD", "#CC9B45"],
     "iconClass": "far fa-calendar-alt"
 }


### PR DESCRIPTION
Adding these options allows users to create shared views that align with other software, such as Outlook, which allows time-based views of multiple users' calendars. The overlapping events were discussed in another issue (#2330) in [this comment](https://github.com/espocrm/espocrm/issues/2330#issuecomment-1141698632), which is understandable for some use cases, but overlapping events are often desirable to see. This change allows users to have the flexibility to choose without incurring maintenance costs or additional work as `FullCalendar` already supports both modes.

The addition of the modes results in two new options in the dropdown menu when creating a shared calendar:

![image](https://github.com/espocrm/espocrm/assets/1170415/48d6eaa1-2ebc-4911-a62d-305bc1d1f30c)
