### PR TITLE
Incorrect metadata path for "validatorClassNameMap"

### DIFF
--- a/application/Espo/Core/FieldValidation/ValidatorFactory.php
+++ b/application/Espo/Core/FieldValidation/ValidatorFactory.php
@@ -31,6 +31,7 @@ namespace Espo\Core\FieldValidation;
 
 use Espo\Core\InjectableFactory;
 use Espo\Core\Utils\Metadata;
+use Espo\Core\Utils\FieldUtil;
 
 use Espo\ORM\Entity;
 use RuntimeException;
@@ -40,7 +41,8 @@ class ValidatorFactory
 
     public function __construct(
         private InjectableFactory $injectableFactory,
-        private Metadata $metadata
+        private Metadata $metadata,
+        private FieldUtil $fieldUtil
     ) {}
 
     public function isCreatable(string $entityType, string $field, string $type): bool
@@ -67,9 +69,11 @@ class ValidatorFactory
      */
     private function getClassName(string $entityType, string $field, string $type): ?string
     {
+        $fieldType = $this->fieldUtil->getEntityTypeFieldParam($entityType, $field, 'type');
+
         return
             $this->metadata->get(['entityDefs', $entityType, 'fields', $field, 'validatorClassNameMap', $type]) ??
-            $this->metadata->get(['fields', $field, 'validatorClassNameMap', $type]);
+            $this->metadata->get(['fields', $fieldType, 'validatorClassNameMap', $type]);
     }
 
     /**


### PR DESCRIPTION
The 'validatorClassNameMap' metadata is incorrectly read from `fields.<fieldName>`.
The correct path should be: `fields.<fieldType>`.

https://github.com/espocrm/espocrm/blob/bcc6edf083567b099a791ec162a79f97cf450c56/application/Espo/Core/FieldValidation/ValidatorFactory.php#L72