### PR TITLE
Add Export functionality to Import detail page panels

### DIFF
--- a/application/Espo/Resources/i18n/en_US/Import.json
+++ b/application/Espo/Resources/i18n/en_US/Import.json
@@ -61,6 +61,7 @@
     "messages": {
         "importRunning": "Import running...",
         "noErrors": "No errors.",
+        "noRecords": "No records were found to export.",
         "utf8": "Should be UTF-8 encoded",
         "duplicatesRemoved": "Duplicates removed",
         "inIdle": "Execute in idle (for big data; via cron)",

--- a/application/Espo/Resources/metadata/clientDefs/Import.json
+++ b/application/Espo/Resources/metadata/clientDefs/Import.json
@@ -15,6 +15,16 @@
 	    		"name": "imported",
 	    		"label": "Imported",
 	    		"view": "views/import/record/panels/imported",
+			"actionList": [
+				{
+					"name": "exportImportRelationship",
+					"action": "exportImportRelationship",
+					"label": "Export",
+					"data": {
+						"handler": "handlers/import"
+					}
+				}
+			],
                 "createDisabled": true,
                 "selectDisabled": true,
                 "unlinkDisabled": true
@@ -24,6 +34,16 @@
 	    		"label": "Duplicates",
 	    		"view": "views/import/record/panels/duplicates",
                 "rowActionsView": "views/import/record/row-actions/duplicates",
+		"actionList": [
+			{
+				"name": "exportImportRelationship",
+				"action": "exportImportRelationship",
+				"label": "Export",
+				"data": {
+					"handler": "handlers/import"
+				}
+			}
+		],
                 "createDisabled": true,
                 "selectDisabled": true,
                 "unlinkDisabled": true
@@ -32,6 +52,16 @@
 	    		"name": "updated",
 	    		"label": "Updated",
 	    		"view": "views/import/record/panels/updated",
+			"actionList": [
+				{
+					"name": "exportImportRelationship",
+					"action": "exportImportRelationship",
+					"label": "Export",
+					"data": {
+						"handler": "handlers/import"
+					}
+				}
+			],
                 "createDisabled": true,
                 "selectDisabled": true,
                 "unlinkDisabled": true

--- a/application/Espo/Resources/routes.json
+++ b/application/Espo/Resources/routes.json
@@ -285,6 +285,11 @@
         "actionClassName": "Espo\\Tools\\Import\\Api\\PostExportErrors"
     },
     {
+        "route": "/Import/:id/exportRelationship/:link",
+        "method": "post",
+        "actionClassName": "Espo\\Tools\\Import\\Api\\PostExportRelationship"
+    },
+    {
         "route": "/Kanban/order",
         "method": "put",
         "actionClassName": "Espo\\Tools\\Kanban\\Api\\PutOrder"

--- a/application/Espo/Tools/Import/Api/PostExportRelationship.php
+++ b/application/Espo/Tools/Import/Api/PostExportRelationship.php
@@ -1,3 +1,4 @@
+<?php
 /************************************************************************
  * This file is part of EspoCRM.
  *
@@ -26,43 +27,46 @@
  * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
  ************************************************************************/
 
-import ActionHandler from 'action-handler';
+namespace Espo\Tools\Import\Api;
 
-class ImportHandler extends ActionHandler {
+use Espo\Core\Acl;
+use Espo\Core\Api\Action;
+use Espo\Core\Api\Request;
+use Espo\Core\Api\Response;
+use Espo\Core\Api\ResponseComposer;
+use Espo\Core\Exceptions\BadRequest;
+use Espo\Core\Exceptions\Forbidden;
+use Espo\Entities\Import;
+use Espo\Services\Import as Service;
 
-    // noinspection JSUnusedGlobalSymbols
-    actionErrorExport() {
-        Espo.Ajax
-            .postRequest(`Import/${this.view.model.id}/exportErrors`)
-            .then(data => {
-                if (!data.attachmentId) {
-                    let message = this.view.translate('noErrors', 'messages', 'Import');
+/**
+ * Exports records related to an import.
+ */
+class PostExportRelationship implements Action
+{
+    public function __construct(private Service $service, private Acl $acl) {}
 
-                    Espo.Ui.warning(message);
+    public function process(Request $request): Response
+    {
+        if (!$this->acl->checkScope(Import::ENTITY_TYPE)) {
+            throw new Forbidden();
+        }
 
-                    return;
-                }
+        $id = $request->getRouteParam('id');
 
-                window.location = this.view.getBasePath() + '?entryPoint=download&id=' + data.attachmentId;
-            });
-    }
+        if (!$id) {
+            throw new BadRequest();
+        }
 
-    // noinspection JSUnusedGlobalSymbols
-	actionExportImportRelationship() {
-	    Espo.Ajax
-            .postRequest(`Import/${this.view.model.id}/exportRelationship/${this.view.link}`)
-            .then(data => {
-                if (!data.attachmentId) {
-                    let message = this.view.translate('noRecords', 'messages', 'Import');
+        $link = $request->getRouteParam('link');
+        if (!$link) {
+            throw new BadRequest();
+        }
 
-                    Espo.Ui.warning(message);
+        $linkedRecords = $this->service->getLinkedRecords($id, $link);
 
-                    return;
-                }
+        $attachmentId = $this->service->exportRecords($linkedRecords);
 
-                window.location = this.view.getBasePath() + '?entryPoint=download&id=' + data.attachmentId;
-            });
+        return ResponseComposer::json(['attachmentId' => $attachmentId]);
     }
 }
-
-export default ImportHandler;


### PR DESCRIPTION
### Background
On the Import detail page there are panels showing the imported, updated and duplicate records associated with that import. It's useful to be able to export these lists for verification purposes. 

Export of these lists can currently be (partially) achieved by opening the "View List" modal, clicking the "Select all" checkbox and selecting Export on the dropdown. This has some shortcomings, however:
- Only the records currently displayed are included in the export, even if many more are present. It is (I think) not possible to export the entire list, and it is easy to mistakenly think the export includes all records.
- The export option is accessible only from the View List modal, and not directly from the detail page where the panels are displayed.

There is existing functionality to export the list of import errors from the Import detail page, but this is not available for the relationship panels (imported, updated, duplicates).

### Description

This pull request implements a CSV export of the records linked to an import.
This adds an "Export" item to the dropdown menu for each panel on the import detail view, in the same style as exists for the import errors list.
The implementation follows the existing functionality for exporting the list of "error" records, and uses the existing CSV export functionality.

![image](https://github.com/espocrm/espocrm/assets/48483526/c42a65a3-abac-413f-a1e0-f6f853aaf275)
