### PR TITLE
Chunked body for Non-AWS S3 endpoints

### DIFF
--- a/application/Espo/Core/FileStorage/Storages/AwsS3.php
+++ b/application/Espo/Core/FileStorage/Storages/AwsS3.php
@@ -57,6 +57,7 @@ class AwsS3 implements Storage
         $credentials = $config->get('awsS3Storage.credentials') ?? null;
         $endpoint = $config->get('awsS3Storage.endpoint') ?? null;
         $pathStyleEndpoint = $config->get('awsS3Storage.pathStyleEndpoint') ?? false;
+        $sendChunkedBody = $config->get('awsS3Storage.sendChunkedBody') ?? null;
 
         if (!$bucketName) {
             throw new RuntimeException("AWS S3 bucket name is not specified in config.");
@@ -72,6 +73,10 @@ class AwsS3 implements Storage
 
         if ($pathStyleEndpoint) {
             $clientOptions['pathStyleEndpoint'] = (bool) $pathStyleEndpoint;
+        }
+
+        if ($sendChunkedBody !== null) {
+            $clientOptions['sendChunkedBody'] = (bool) $sendChunkedBody;
         }
 
         if ($credentials && is_array($credentials)) {


### PR DESCRIPTION
Related to https://github.com/espocrm/espocrm/issues/2919

When testing Cloudflare R2 endpoint with larger files I encountered the following error:

```
ERROR: (501) HTTP 501 returned for "eu.r2.cloudflarestorage.com/6761da60-e9c2-4794-9303-f404f92360ea".
Code:    NotImplemented
Message: STREAMING-AWS4-HMAC-SHA256-PAYLOAD not implemented
Type:
Detail:   ; POST /Attachment; line: 402, file: /var/www/html/vendor/async-aws/core/src/Response.php
```

To fix this I needed to set `sendChunkedBody` as `false`.

Regarding this line: `$sendChunkedBody = $config->get('awsS3Storage.sendChunkedBody') ?? null;`

The reason `sendChunkedBody` defaults to `null` is because the documentation for AsyncAws is unclear. Here, it suggests that the default value is `false`: https://async-aws.com/configuration.html#sendchunkedbody. However, here, it seems to suggest that it is enabled by default: https://async-aws.com/clients/s3.html#chunked-body. To avoid confusion, it might be better not to pass this parameter to the client by default, or to have a clearer name such as `sendChunkedBodyDisabled`.