### PR TITLE
[PHP 8.4] Fix: Curl `CURLOPT_BINARYTRANSFER` deprecated

### DIFF
--- a/application/Espo/Classes/TemplateHelpers/GoogleMaps.php
+++ b/application/Espo/Classes/TemplateHelpers/GoogleMaps.php
@@ -215,7 +215,6 @@ class GoogleMaps implements Helper
         curl_setopt($c, \CURLOPT_TIMEOUT, 10);
         curl_setopt($c, \CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($c, \CURLOPT_FOLLOWLOCATION, 1);
-        curl_setopt($c, \CURLOPT_BINARYTRANSFER, 1);
 
         $raw = curl_exec($c);
 

--- a/application/Espo/Tools/Attachment/UploadUrlService.php
+++ b/application/Espo/Tools/Attachment/UploadUrlService.php
@@ -132,7 +132,6 @@ class UploadUrlService
         $opts[\CURLOPT_CONNECTTIMEOUT] = 10;
         $opts[\CURLOPT_TIMEOUT] = 10;
         $opts[\CURLOPT_HEADER] = true;
-        $opts[\CURLOPT_BINARYTRANSFER] = true;
         $opts[\CURLOPT_VERBOSE] = true;
         $opts[\CURLOPT_SSL_VERIFYPEER] = true;
         $opts[\CURLOPT_SSL_VERIFYHOST] = 2;


### PR DESCRIPTION
The `CURLOPT_BINARYTRANSFER` PHP constant from the Curl extension was no-op since PHP 5.1, and is deprecated in PHP 8.4. This removes the constant usage to avoid the deprecation notice in PHP 8.4 and later.

Because this constant was no-op since PHP 5.1 (circa 2005), this change has no impact.

See:

 - [PHP.Watch - PHP 8.4 - Curl: CURLOPT_BINARYTRANSFER deprecated](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated)
 - [commit](https://github.com/php/php-src/commit/fc16285538e96ecb35d017231051f83dcbd8b55b)