### PR TITLE
Fix for long messages in the logger causing a runtime exception

### DIFF
--- a/application/Espo/Core/Log/Handler/EspoFileHandler.php
+++ b/application/Espo/Core/Log/Handler/EspoFileHandler.php
@@ -97,7 +97,7 @@ class EspoFileHandler extends MonologStreamHandler
 
         $message = substr($record->message, 0, $this->maxErrorMessageLength) . '...';
 
-        $record = $record->with('message', $message);
+        $record = $record->with(message: $message);
 
         return $this->getFormatter()->format($record);
     }


### PR DESCRIPTION
Incorrect use of `with` method causes long error messages to fail with RuntimeException. 

```
Error message: Named parameter $channel overwrites previous argument; at /home/******/public_html/application/Espo/Core/Log/Handler/EspoFileHandler.php:88.
```

https://github.com/Seldaek/monolog/blob/479c936d2c230d8c467bdb3882afab45a6e6b8ad/src/Monolog/LogRecord.php#L116-L122

![image](https://github.com/espocrm/espocrm/assets/44263817/99b23b48-29da-452e-a356-df3d1576a6d3)

Explanation: incorrect usage of `with` method causes `$args[1]` to be set to string. Constructor parameter#1 also happens to be `channel` with is also present in the `$args` array. `$args` is then used to initialize the instance of new LogRecord. This causes named parameter `$channel` to overwrite previous argument on the position `#1`.