### PR TITLE
Map provider config paramater

### DIFF
--- a/application/Espo/Resources/i18n/en_US/Settings.json
+++ b/application/Espo/Resources/i18n/en_US/Settings.json
@@ -167,7 +167,8 @@
         "oidcAllowRegularUserFallback": "OIDC Allow fallback login for regular users",
         "oidcAllowAdminUser": "OIDC Allow OIDC login for admin users",
         "oidcLogoutUrl": "OIDC Logout URL",
-        "pdfEngine": "PDF Engine"
+        "pdfEngine": "PDF Engine",
+        "mapProvider": "Map Provider"
     },
     "options": {
         "authenticationMethod": {

--- a/application/Espo/Resources/layouts/Settings/settings.json
+++ b/application/Espo/Resources/layouts/Settings/settings.json
@@ -51,7 +51,7 @@
             [{"name": "followCreatedEntities"}, {"name": "emailAddressIsOptedOutByDefault"}],
             [{"name": "aclAllowDeleteCreated"}, {"name": "cleanupDeletedRecords"}],
             [{"name": "exportDisabled"}, {"name": "b2cMode"}],
-            [{"name": "pdfEngine"}, false]
+            [{"name": "pdfEngine"}, {"name": "mapProvider"}]
         ]
 
     },

--- a/application/Espo/Resources/metadata/entityDefs/Settings.json
+++ b/application/Espo/Resources/metadata/entityDefs/Settings.json
@@ -885,6 +885,10 @@
         "pdfEngine": {
             "type": "enum",
             "view": "views/settings/fields/pdf-engine"
+        },
+        "mapProvider": {
+            "type": "enum",
+            "view": "views/settings/fields/map-provider"
         }
     }
 }

--- a/client/src/views/settings/fields/map-provider.js
+++ b/client/src/views/settings/fields/map-provider.js
@@ -1,0 +1,41 @@
+/************************************************************************
+ * This file is part of EspoCRM.
+ *
+ * EspoCRM – Open Source CRM application.
+ * Copyright (C) 2014-2024 Yurii Kuznietsov, Taras Machyshyn, Oleksii Avramenko
+ * Website: https://www.espocrm.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
+ ************************************************************************/
+
+define('views/settings/fields/map-provider', ['views/fields/enum'], function (Dep) {
+
+    return Dep.extend({
+
+        setupOptions: function () {
+            this.params.options = Object.keys(this.getMetadata().get(['app', 'mapProviders']));
+
+            if (this.params.options.length === 0) {
+                this.params.options = [''];
+            }
+        },
+    });
+});


### PR DESCRIPTION
Implmenting a custom map provider is a great option, however there is no way for the user to choose which provider to apply to the maps fields in the system and therefore the system would always apply Google as default config, adding a map provider config params to the UI would allow the user to choose which map provider to use. 