### PR TITLE
fix entity rename command

### DIFF
--- a/application/Espo/Tools/EntityManager/Rename/Renamer.php
+++ b/application/Espo/Tools/EntityManager/Rename/Renamer.php
@@ -195,10 +195,6 @@ class Renamer
             return Result::createFail(FailReason::NAME_USED);
         }
 
-        if (!$this->fileManager->isFile($this->getClassFilePath(ClassType::ENTITY, $entityType))) {
-            return Result::createFail(FailReason::NOT_CUSTOM);
-        }
-
         if (!$this->fileManager->isFile($this->getClassFilePath(ClassType::CONTROLLER, $entityType))) {
             return Result::createFail(FailReason::NOT_CUSTOM);
         }


### PR DESCRIPTION
In recent espo versions there is no php file created automatically in `entities` folder, this will always cause an error when renaming new created custom entities.