### PR TITLE
Print extension version in console using command.php

### DIFF
--- a/application/Espo/Core/Console/Commands/Extension.php
+++ b/application/Espo/Core/Console/Commands/Extension.php
@@ -274,6 +274,7 @@ class Extension implements Command
             $isInstalled = $extension->get('isInstalled');
 
             $io->writeLine(' Name: ' . $extension->get('name'));
+            $io->writeLine(' Version: ' . $extension->get('version'));
             $io->writeLine(' ID: ' . $extension->getId());
             $io->writeLine(' Installed: ' . ($isInstalled ? 'yes' : 'no'));
 


### PR DESCRIPTION
Along with extension name prints extension version when using 'php command.php extensions --list' command.

Useful for automatic server data management.