### PR TITLE
fix: Resolve error 500 with Microsoft Office 365 OIDC authentication …

### DIFF
--- a/application/Espo/Core/Authentication/Authentication.php
+++ b/application/Espo/Core/Authentication/Authentication.php
@@ -236,7 +236,8 @@ class Authentication
         if (
             !$result->isSecondStepRequired() &&
             !$authToken &&
-            $this->configDataProvider->isTwoFactorEnabled()
+            $this->configDataProvider->isTwoFactorEnabled() &&
+            $username !== '**oidc'
         ) {
             $result = $this->processTwoFactor($result, $request);
 


### PR DESCRIPTION
Solves the problem of error 500 when using Microsoft office 365 authentication (OIDC) with two-factor authentication enabled in Espocrm. 
Currently, a ZFA code query is also executed with OIDC authentication and enabled ZFA in Espocrm.  
Goal: Internal authentication in Espocrm and authentication with external authentication providers (OIDC) should be separated. Either the authentication is carried out with the internal authentication, which queries the zfa code when two-factor authentication is activated in Espocrm, or the authentication is carried out with an OIDC provider that uses its own two-factor methods, in which case no ZFA code query from EspoCrm is necessary. 