### PR TITLE
Lower case and trim keywords in admin index quick search

### DIFF
--- a/client/src/views/admin/index.js
+++ b/client/src/views/admin/index.js
@@ -84,6 +84,8 @@ class AdminIndexView extends View {
                     if (item.description) {
                         item.keywords = (this.getLanguage().get('Admin', 'keywords', item.description) || '')
                             .split(',');
+                        
+                        item.keywords = item.keywords.map(keyword => keyword.trim().toLowerCase());
                     } else {
                         item.keywords = [];
                     }


### PR DESCRIPTION
This is helpful when translation written with spaces or first capital letter