### PR TITLE
admin ACL for clientDefs.json schema

### DIFF
--- a/schema/metadata/clientDefs.json
+++ b/schema/metadata/clientDefs.json
@@ -555,6 +555,7 @@
                                     "read",
                                     "edit",
                                     "delete",
+                                    "admin",
                                     "stream"
                                 ]
                             },
@@ -860,6 +861,7 @@
                         "read",
                         "edit",
                         "delete",
+                        "admin",
                         "stream"
                     ],
                     "description": "An action to check access to. If no access, the item is not displayed."


### PR DESCRIPTION
add Admin ACL for clientDefs, I don't know if it's supported anywhere else apart from buttons and dropdowns, it would be nice to have it where it's supported so when using Schema it doesn't show the parameter as wrong.