### PR TITLE
compose.js super.afterSave

### DIFF
--- a/client/src/views/email/record/compose.js
+++ b/client/src/views/email/record/compose.js
@@ -215,7 +215,7 @@ class EmailComposeRecordView extends EditRecordView {
     }
 
     afterSave() {
-        super.afterRender();
+        super.afterSave();
 
         if (this.isSending && this.model.get('status') === 'Sent') {
             Espo.Ui.success(this.translate('emailSent', 'messages', 'Email'));


### PR DESCRIPTION
This pull request fixes compose.js file where the afterSave() method was incorrectly calling super.afterRender() instead of super.afterSave().

When this was still an AMD module it was calling Dep.prototype.afterSave.call(this);

https://github.com/espocrm/espocrm/commit/d7063a914f9d0112b1905fe70245b493c0c99a4d#diff-117135453cb4900bd25d798364599ab10aa07e35722300e367a69b9df90e85a3L216


