### PR TITLE
Fix typo: fix typo in address country - is preferred field tooltip.

### DIFF
--- a/application/Espo/Resources/i18n/en_US/AddressCountry.json
+++ b/application/Espo/Resources/i18n/en_US/AddressCountry.json
@@ -9,7 +9,7 @@
     },
     "tooltips": {
         "code": "ISO 3166-1 alpha-2 code.",
-        "isPreferred": "Preferred counties appear first in the picklist."
+        "isPreferred": "Preferred countries appear first in the picklist."
     },
     "messages": {
         "confirmPopulateDefaults": "All existing countries will be deleted, the default country list will be created. It won't be possible to revert the operation.\n\nAre you sure?"


### PR DESCRIPTION
Fix typo counties.  