### PR TITLE
Allow to customise the order of the activities panel

### DIFF
--- a/application/Espo/Modules/Crm/Tools/Activities/Api/Get.php
+++ b/application/Espo/Modules/Crm/Tools/Activities/Api/Get.php
@@ -74,9 +74,12 @@ class Get implements Action
         $offset = $searchParams->getOffset();
         $maxSize = $searchParams->getMaxSize();
 
+        $orderBy = $searchParams->getOrderBy();
+        $order = $searchParams->getOrder();
+
         $targetEntityType = $request->getQueryParam('entityType');
 
-        $fetchParams = new ActivitiesFetchParams($maxSize, $offset, $targetEntityType);
+        $fetchParams = new ActivitiesFetchParams($maxSize, $offset, $targetEntityType, $orderBy, $order);
 
         $recordCollection = $type === 'history' ?
             $this->service->getHistory($parentType, $id, $fetchParams) :

--- a/application/Espo/Modules/Crm/Tools/Activities/FetchParams.php
+++ b/application/Espo/Modules/Crm/Tools/Activities/FetchParams.php
@@ -34,15 +34,21 @@ class FetchParams
     private ?int $maxSize;
     private ?int $offset;
     private ?string $entityType;
+    private ?string $orderBy;
+    private ?string $order;
 
     public function __construct(
         ?int $maxSize,
         ?int $offset,
-        ?string $entityType
+        ?string $entityType,
+        ?string $orderBy,
+        ?string $order
     ) {
         $this->maxSize = $maxSize;
         $this->offset = $offset;
         $this->entityType = $entityType;
+        $this->orderBy = $orderBy;
+        $this->order = $order;
     }
 
     public function getMaxSize(): ?int
@@ -58,5 +64,15 @@ class FetchParams
     public function getEntityType(): ?string
     {
         return $this->entityType;
+    }
+
+    public function getOrderBy(): ?string
+    {
+        return $this->orderBy;
+    }
+
+    public function getOrder(): ?string
+    {
+        return $this->order;
     }
 }

--- a/application/Espo/Modules/Crm/Tools/Activities/Service.php
+++ b/application/Espo/Modules/Crm/Tools/Activities/Service.php
@@ -651,7 +651,9 @@ class Service
                         ::create(
                             $query->getSelect()[2]->getExpression()
                         )
-                        ->withDesc()
+                        ->withDirection(
+                            $query->getSelect()[3]->getExpression()
+                        )
                 );
 
                 $newQueryList[] = $subBuilder->build();
@@ -684,8 +686,11 @@ class Service
 
             $totalCount = $row['count'];
         }
+        
+        $orderBy = $params->getOrderBy();
+        $order = $params->getOrder();
 
-        $builder->order('dateStart', 'DESC');
+        $builder->order($orderBy, $order);
 
         if ($scope === User::ENTITY_TYPE) {
             $maxSizeQ++;

--- a/application/Espo/Modules/Crm/Tools/Activities/Service.php
+++ b/application/Espo/Modules/Crm/Tools/Activities/Service.php
@@ -687,8 +687,8 @@ class Service
             $totalCount = $row['count'];
         }
         
-        $orderBy = $params->getOrderBy();
-        $order = $params->getOrder();
+        $orderBy = $params->getOrderBy() ?? 'dateStart';
+        $order = $params->getOrder() ?? 'DESC';
 
         $builder->order($orderBy, $order);
 


### PR DESCRIPTION
Currently the activities are ordered by dateStart and ordered in descending mode. 
However if someone wants to change that it won't work even if they use a custom activities view and provide an orderBy and order properties. This fix the issues and allow the user to have that flexibility so they could customise how the records are ordered on the activities panels. 