### PR TITLE
Meeting Send button translation Global.json

### DIFF
--- a/application/Espo/Resources/i18n/en_US/Global.json
+++ b/application/Espo/Resources/i18n/en_US/Global.json
@@ -319,7 +319,8 @@
         "View User Access": "View User Access",
         "Reacted": "Reacted",
         "Reaction Removed": "Reaction Removed",
-        "Reactions": "Reactions"
+        "Reactions": "Reactions",
+        "Send": "Send"
     },
     "messages": {
         "pleaseWait": "Please wait...",


### PR DESCRIPTION
Adding language string for "Send" label, this was missing and as such the "Meeting" send invitation/cancellation button does not have translations.

![image](https://github.com/user-attachments/assets/91c9f7b5-a434-49d7-aead-1a5ca74abca4)
