### PR TITLE
Add Vazirmatn font support for RTL Farsi mode

### DIFF
--- a/frontend/less/espo-rtl/fonts-rtl.less
+++ b/frontend/less/espo-rtl/fonts-rtl.less
@@ -1,0 +1,31 @@
+@font-face {
+    font-family: "Vazirmatn";
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url("@{font-path}/vazirmatn/Vazirmatn-Regular.woff2") format("woff2");
+}
+
+@font-face {
+    font-family: "Vazirmatn";
+    font-style: normal;
+    font-weight: 500;
+    font-display: swap;
+    src: url("@{font-path}/vazirmatn/Vazirmatn-Medium.woff2") format("woff2");
+}
+
+@font-face {
+    font-family: "Vazirmatn";
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url("@{font-path}/vazirmatn/Vazirmatn-SemiBold.woff2") format("woff2");
+}
+
+@font-face {
+    font-family: "Vazirmatn";
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
+    src: url("@{font-path}/vazirmatn/Vazirmatn-Bold.woff2") format("woff2");
+}

--- a/frontend/less/espo-rtl/iframe/main.less
+++ b/frontend/less/espo-rtl/iframe/main.less
@@ -4,4 +4,9 @@
 @import "../variables.less";
 @import "../../espo/root-variables.less";
 @import "../../espo/fonts.less";
+@import "../fonts-rtl.less";
 @import "../../espo/iframe/iframe.less";
+
+html[dir="rtl"][data-language="fa"] {
+    font-family: "Vazirmatn", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+}

--- a/frontend/less/espo-rtl/main.less
+++ b/frontend/less/espo-rtl/main.less
@@ -1,4 +1,5 @@
 @import "../espo/init.less";
+@import "fonts-rtl.less";
 @import "bootstrap-rtl/bootstrap-rtl.less";
 @import "../espo/value-variables.less";
 @import "../espo/variables.less";
@@ -16,4 +17,8 @@
 
 body {
     --theme-name: EspoRtl;
+}
+
+html[dir="rtl"][data-language="fa"] {
+    font-family: "Vazirmatn", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
 }


### PR DESCRIPTION
- Create fonts-rtl.less with Vazirmatn font configuration
- Update RTL main.less to use Vazirmatn font for Farsi language
- Add font support in RTL iframes
- Font will be applied when dir=rtl and lang=fa