### PR TITLE
Add Select Appliers Support for Kanban View

### DIFF
--- a/application/Espo/Tools/Kanban/Kanban.php
+++ b/application/Espo/Tools/Kanban/Kanban.php
@@ -35,6 +35,7 @@ use Espo\Core\Exceptions\Forbidden;
 use Espo\Core\FieldProcessing\ListLoadProcessor;
 use Espo\Core\FieldProcessing\Loader\Params as FieldLoaderParams;
 use Espo\Core\Record\Collection;
+use Espo\Core\Record\Select\ApplierClassNameListProvider;
 use Espo\Core\Record\ServiceContainer as RecordServiceContainer;
 use Espo\Core\Select\SearchParams;
 use Espo\Core\Select\SelectBuilderFactory;
@@ -59,7 +60,8 @@ class Kanban
         private SelectBuilderFactory $selectBuilderFactory,
         private EntityManager $entityManager,
         private ListLoadProcessor $listLoadProcessor,
-        private RecordServiceContainer $recordServiceContainer
+        private RecordServiceContainer $recordServiceContainer,
+        private ApplierClassNameListProvider $applierClassNameListProvider
     ) {}
 
     public function setEntityType(string $entityType): self
@@ -142,6 +144,9 @@ class Kanban
             ->from($this->entityType)
             ->withStrictAccessControl()
             ->withSearchParams($searchParams)
+            ->withAdditionalApplierClassNameList(
+                $this->applierClassNameListProvider->get($this->entityType)
+            )
             ->build();
 
         $statusField = $this->getStatusField();


### PR DESCRIPTION
Hi Yuri,

This extends the Select Appliers feature to Kanban, ensuring it works like in normal record list. While Select Appliers is a great feature, it hasn't been implemented for Kanban yet—this update addresses that.

Looking forward to your review!

ref: https://github.com/espocrm/espocrm/pull/2629/files