### PR TITLE
Hide Plus button on kanban header when createDisabled is true

### DIFF
--- a/client/src/views/record/kanban.js
+++ b/client/src/views/record/kanban.js
@@ -200,7 +200,7 @@ class KanbanRecordView extends ListRecordView {
         },
         /** @this KanbanRecordView */
         'mouseenter th.group-header': function (e) {
-            if (!this.isCreatable) {
+            if (!this.isCreatable || this.getMetadata().get(['clientDefs', this.entityType, 'createDisabled'])) {
                 return;
             }
 


### PR DESCRIPTION
- Check if `createDisabled` is set to `true` in clientDefs.
- Hide the plus button in the kanban header when `createDisabled` is true.