### PR TITLE
Add Inject attribute for property injection

### DIFF
--- a/application/Espo/Core/Di/Inject.php
+++ b/application/Espo/Core/Di/Inject.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Espo\Core\Di;
+
+use Attribute;
+
+/**
+ * Attribute for property injection.
+ * Can be used on properties to inject services from the container.
+ * 
+ * If a service name is not specified, it will be derived from the property type.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Inject
+{
+	/**
+	 * @param ?string $name The service name. If null, the name will be derived from the property or parameter type.
+	 */
+	public function __construct(
+		public readonly ?string $name = null
+	) {
+	}
+}


### PR DESCRIPTION
I've been thinking of this change as I don't really like the Aware/Setter pattern because it requires you to implement the pattern for your own services.

With this change it would be possible to do the following to inject a dependency that exists in the container:
```php
<?php

class MyService 
{
    public function doSomething(): string
    {
        return 'test';
    }
}
```

```php
<?php

use MyService;
use Espo\Core\Di\Inject;

class Foo()
{
    #[Inject]
    private MyService $myService;

    public function bar(): void;
    {
        $test = $this->myService->doSomething();
    }
}
```

