### PR TITLE
Fix getActivitiesUserMeetingQueryin Activities service for Postgres

### DIFF
--- a/application/Espo/Modules/Crm/Tools/Activities/Service.php
+++ b/application/Espo/Modules/Crm/Tools/Activities/Service.php
@@ -131,7 +131,7 @@ class Service
                     'parentId',
                     'status',
                     Field::CREATED_AT,
-                    ['null', 'hasAttachment'],
+                    [false, 'hasAttachment'],
                 ])
                 ->leftJoin(
                     'MeetingUser',


### PR DESCRIPTION
The code with 'false' produces this error in Postgres:
[2025-04-03 18:21:50] CRITICAL: (42804) SQLSTATE[42804]: Datatype mismatch: 7 ERROR:  UNION types text and boolean cannot be matched LINE 1: ...AS "status", "email"."created_at" AS "createdAt", "email"."h...                                                              ^ :: GET /Activities/User/67d2dcb1e6195a058/history ::