### PR TITLE
Fixes autoload schema

### DIFF
--- a/schema/autoload.json
+++ b/schema/autoload.json
@@ -19,7 +19,7 @@
                 "type": "string"
             }
         },
-        "autoloadFileList": {
+        "files": {
             "description": "Autoload PHP files.",
             "type": "array",
             "items": {


### PR DESCRIPTION
https://getcomposer.org/doc/04-schema.md#files

I always used 'files' and it worked. Today I noticed that vscode does not autocomplete the key.