### PR TITLE
fixes composer psr-4 compliance errors

### DIFF
--- a/application/Espo/Core/Formula/Functions/DatetimeGroup/DateType.php
+++ b/application/Espo/Core/Formula/Functions/DatetimeGroup/DateType.php
@@ -27,7 +27,7 @@
  * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
  ************************************************************************/
 
-namespace Espo\Core\Formula\Functions\DateTimeGroup;
+namespace Espo\Core\Formula\Functions\DatetimeGroup;
 
 use Espo\Core\Di;
 

--- a/application/Espo/Core/Formula/Functions/DatetimeGroup/DayOfWeekType.php
+++ b/application/Espo/Core/Formula/Functions/DatetimeGroup/DayOfWeekType.php
@@ -27,7 +27,7 @@
  * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
  ************************************************************************/
 
-namespace Espo\Core\Formula\Functions\DateTimeGroup;
+namespace Espo\Core\Formula\Functions\DatetimeGroup;
 
 use Espo\Core\Di;
 

--- a/application/Espo/Core/Formula/Functions/DatetimeGroup/FormatType.php
+++ b/application/Espo/Core/Formula/Functions/DatetimeGroup/FormatType.php
@@ -27,7 +27,7 @@
  * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
  ************************************************************************/
 
-namespace Espo\Core\Formula\Functions\DateTimeGroup;
+namespace Espo\Core\Formula\Functions\DatetimeGroup;
 
 use Espo\Core\Di;
 

--- a/application/Espo/Core/Formula/Functions/DatetimeGroup/HourType.php
+++ b/application/Espo/Core/Formula/Functions/DatetimeGroup/HourType.php
@@ -27,7 +27,7 @@
  * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
  ************************************************************************/
 
-namespace Espo\Core\Formula\Functions\DateTimeGroup;
+namespace Espo\Core\Formula\Functions\DatetimeGroup;
 
 use Espo\Core\Di;
 

--- a/application/Espo/Core/Formula/Functions/DatetimeGroup/MinuteType.php
+++ b/application/Espo/Core/Formula/Functions/DatetimeGroup/MinuteType.php
@@ -27,7 +27,7 @@
  * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
  ************************************************************************/
 
-namespace Espo\Core\Formula\Functions\DateTimeGroup;
+namespace Espo\Core\Formula\Functions\DatetimeGroup;
 
 use Espo\Core\Di;
 

--- a/application/Espo/Core/Formula/Functions/DatetimeGroup/YearType.php
+++ b/application/Espo/Core/Formula/Functions/DatetimeGroup/YearType.php
@@ -27,7 +27,7 @@
  * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
  ************************************************************************/
 
-namespace Espo\Core\Formula\Functions\DateTimeGroup;
+namespace Espo\Core\Formula\Functions\DatetimeGroup;
 
 use Espo\Core\Di;
 

--- a/application/Espo/Core/Formula/Functions/ObjectGroup/CloneDeepType.php
+++ b/application/Espo/Core/Formula/Functions/ObjectGroup/CloneDeepType.php
@@ -36,7 +36,7 @@ use Espo\Core\Utils\ObjectUtil;
 
 use stdClass;
 
-class cloneDeepType extends BaseFunction
+class CloneDeepType extends BaseFunction
 {
     public function process(ArgumentList $args)
     {


### PR DESCRIPTION
I randomly stumbled upon this in my gitlab pipeline, it doesn't seem intentional but it doesn't actually seem to affect functionality AFAIK. 


$ composer dump-autoload -o
Generating optimized autoload files
Class Espo\Core\Formula\Functions\DateTimeGroup\DateType located in /usr/src/espocrm/application/Espo/Core/Formula/Functions/DatetimeGroup/DateType.php does not comply with psr-4 autoloading standard (rule: Espo\ => /usr/src/espocrm/application/Espo). Skipping.
Class Espo\Core\Formula\Functions\DateTimeGroup\HourType located in /usr/src/espocrm/application/Espo/Core/Formula/Functions/DatetimeGroup/HourType.php does not comply with psr-4 autoloading standard (rule: Espo\ => /usr/src/espocrm/application/Espo). Skipping.
Class Espo\Core\Formula\Functions\DateTimeGroup\YearType located in /usr/src/espocrm/application/Espo/Core/Formula/Functions/DatetimeGroup/YearType.php does not comply with psr-4 autoloading standard (rule: Espo\ => /usr/src/espocrm/application/Espo). Skipping.
Class Espo\Core\Formula\Functions\DateTimeGroup\FormatType located in /usr/src/espocrm/application/Espo/Core/Formula/Functions/DatetimeGroup/FormatType.php does not comply with psr-4 autoloading standard (rule: Espo\ => /usr/src/espocrm/application/Espo). Skipping.
Class Espo\Core\Formula\Functions\DateTimeGroup\MinuteType located in /usr/src/espocrm/application/Espo/Core/Formula/Functions/DatetimeGroup/MinuteType.php does not comply with psr-4 autoloading standard (rule: Espo\ => /usr/src/espocrm/application/Espo). Skipping.
Class Espo\Core\Formula\Functions\DateTimeGroup\DayOfWeekType located in /usr/src/espocrm/application/Espo/Core/Formula/Functions/DatetimeGroup/DayOfWeekType.php does not comply with psr-4 autoloading standard (rule: Espo\ => /usr/src/espocrm/application/Espo). Skipping.
Class Espo\Core\Formula\Functions\ObjectGroup\cloneDeepType located in /usr/src/espocrm/application/Espo/Core/Formula/Functions/ObjectGroup/CloneDeepType.php does not comply with psr-4 autoloading standard (rule: Espo\ => /usr/src/espocrm/application/Espo). Skipping.
Generated optimized autoload files containing 5017 classes