### PR TITLE
French e-mail template for password reset is now translated

### DIFF
--- a/application/Espo/Resources/templates/passwordChangeLink/fr_FR/body.tpl
+++ b/application/Espo/Resources/templates/passwordChangeLink/fr_FR/body.tpl
@@ -1,1 +1,1 @@
-<p>You can change your password by following this link <a href="{{link}}">{{link}}</a>. This unique URL will be expired soon.</p>
+<p>Vous pouvez modifier votre mot de passe en suivant ce lien <a href="{{link}}">{{link}}</a>. Cette URL unique expirera bientôt.</p>


### PR DESCRIPTION
I translated the `.tpl` file containing the e-mail body that's sent to the user resetting its password.