### PR TITLE
Update config.php

### DIFF
--- a/application/Espo/Resources/defaults/config.php
+++ b/application/Espo/Resources/defaults/config.php
@@ -241,7 +241,7 @@ return [
     'cleanupAudit' => true,
     'cleanupAuditPeriod' => '3 months',
     'cleanupAppLog' => true,
-    'cleanupAppLogPeriod' => '30 days',
+    'cleanupAppLogPeriod' => '1 month',
     'appLogAdminAllowed' => false,
     'currencyFormat' => 2,
     'currencyDecimalPlaces' => 2,


### PR DESCRIPTION
"cleanupAppLogPeriod": {
			"type": "enum",
			"optionsReference": "Settings.cleanupJobPeriod"
		},
		"cleanupJobPeriod": {
			"type": "enum",
			"options": [
				"1 hour",
				"12 hours",
				"1 day",
				"2 days",
				"10 days",
				"15 days",
				"1 month",
				"2 months",
				"6 months"
			]
		},

the default was 30 days < not valid