### PR TITLE
keep user-addressed emails visible when routed to a Group Folder

### DIFF
--- a/application/Espo/Classes/Select/Email/Where/ItemConverters/InFolder.php
+++ b/application/Espo/Classes/Select/Email/Where/ItemConverters/InFolder.php
@@ -30,10 +30,12 @@
 namespace Espo\Classes\Select\Email\Where\ItemConverters;
 
 use Espo\Core\Name\Link;
+use Espo\Core\Select\SelectBuilderFactory;
 use Espo\Core\Select\Where\ItemConverter;
 use Espo\Core\Select\Where\Item;
 
 use Espo\Entities\Email;
+use Espo\Entities\GroupEmailFolder;
 use Espo\ORM\Name\Attribute;
 use Espo\ORM\Query\SelectBuilder as QueryBuilder;
 use Espo\ORM\Query\Part\WhereItem as WhereClauseItem;
@@ -51,7 +53,8 @@ class InFolder implements ItemConverter
     public function __construct(
         private User $user,
         private EntityManager $entityManager,
-        private JoinHelper $joinHelper
+        private JoinHelper $joinHelper,
+        private SelectBuilderFactory $selectBuilderFactory
     ) {}
 
     public function convert(QueryBuilder $queryBuilder, Item $item): WhereClauseItem
@@ -74,6 +77,8 @@ class InFolder implements ItemConverter
     {
         $this->joinEmailUser($queryBuilder);
 
+        $groupEmailFoldersIds = $this->getUserGroupEmailFoldersIds();
+
         $whereClause = [
             Email::ALIAS_INBOX . '.inTrash' => false,
             Email::ALIAS_INBOX . '.inArchive' => false,
@@ -84,7 +89,10 @@ class InFolder implements ItemConverter
                     Email::STATUS_ARCHIVED,
                     Email::STATUS_SENT,
                 ],
-                'groupFolderId' => null,
+                'OR' => [
+                    'groupFolderId' => null,
+                    'groupFolderId!=' => $groupEmailFoldersIds,
+                ]
             ],
         ];
 
@@ -249,5 +257,29 @@ class InFolder implements ItemConverter
         }
 
         return $emailAddressIdList;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getUserGroupEmailFoldersIds(): array
+    {
+        $selectBuilder = $this->selectBuilderFactory
+            ->create()
+            ->from(GroupEmailFolder::ENTITY_TYPE)
+            ->withAccessControlFilter();
+
+        $groupEmailFolders = $this->entityManager
+            ->getRDBRepository(GroupEmailFolder::ENTITY_TYPE)
+            ->clone($selectBuilder->build())
+            ->find();
+
+        $groupEmailFoldersIds = [];
+
+        foreach ($groupEmailFolders as $groupEmailFolder) {
+            $groupEmailFoldersIds[] = $groupEmailFolder->getId();
+        }
+
+        return $groupEmailFoldersIds;
     }
 }

--- a/application/Espo/Classes/Select/Email/Where/ItemConverters/InFolder.php
+++ b/application/Espo/Classes/Select/Email/Where/ItemConverters/InFolder.php
@@ -260,7 +260,7 @@ class InFolder implements ItemConverter
     }
 
     /**
-     * @return array
+     * @return array<string>
      */
     protected function getUserGroupEmailFoldersIds(): array
     {

--- a/application/Espo/Classes/Select/Email/Where/ItemConverters/InFolder.php
+++ b/application/Espo/Classes/Select/Email/Where/ItemConverters/InFolder.php
@@ -262,10 +262,11 @@ class InFolder implements ItemConverter
     /**
      * @return array<string>
      */
-    protected function getUserGroupEmailFoldersIds(): array
+    private function getUserGroupEmailFoldersIds(): array
     {
         $selectBuilder = $this->selectBuilderFactory
             ->create()
+            ->forUser($this->user)
             ->from(GroupEmailFolder::ENTITY_TYPE)
             ->withAccessControlFilter();
 


### PR DESCRIPTION
**Describe the bug**
When an incoming email is addressed to a user's personal email (To:) and the email is CC'd to a group email that has a Group Folder configured, the mail processing moves the email to that Group Folder. If the user does not have access to the Group Folder, the user cannot see the email in their inbox nor in the Group Folder.

**To Reproduce (MANDATORY, DO NOT REMOVE)**
Explicit steps to reproduce the behavior:
1. Create/configure a Group email account (e.g. group@example.com) and assign it a Group Folder (e.g. "Sales").
2. Ensure a user account (e.g. user@example.com) does *not* have access permissions to that Group Folder.
3. Send an email where:
   - To: user@example.com
   - CC: group@example.com
4. Observe that the email is moved into the Group Folder and no copy appears in the user's personal inbox. Because the user lacks access to the Group Folder, they cannot locate the email anywhere in EspoCRM.

**Observed / Actual behavior**
The email is moved to the Group Folder (assigned to the CC'd group account) and therefore disappears from the user's inbox. Since the user lacks permissions on that Group Folder, they cannot view the email at all.

**Expected behavior**
If a recipient (To:) does not have access to a Group Folder that an email would be routed into (because of a CC'd group account), EspoCRM should **not** silently filter/move the email out of the recipient's inbox. Possible acceptable behavior:
Show the email to both the recipient's inbox and the Group Folder

**EspoCRM version**
Please specify the EspoCRM version(s) where this occurs (e.g. `9.1.8`).

**Additional context**

This change updates the inbox filter to include emails that are addressed to the current user even when groupFolderId is present.