### PR TITLE
fix incorrect parent setting in compose modal

### DIFF
--- a/client/src/views/fields/email.js
+++ b/client/src/views/fields/email.js
@@ -548,7 +548,7 @@ class EmailFieldView extends VarcharFieldView {
 
         if (
             this.model.collection &&
-            ('patentModel' in this.model.collection) &&
+            ('parentModel' in this.model.collection) &&
             this.model.collection.parentModel
         ) {
             if (this.checkParentTypeAvailability(this.model.collection.parentModel.entityType)) {


### PR DESCRIPTION
When clicking an **email address** in the small list view of a relationship panel, the parent record was set incorrectly in the compose modal due to the typo.