### PR TITLE
entity-removed.js typo

### DIFF
--- a/client/src/views/notification/items/entity-removed.js
+++ b/client/src/views/notification/items/entity-removed.js
@@ -28,7 +28,7 @@
 
 import BaseNotificationItemView from 'views/notification/items/base';
 
-class EmailRemovedNotificationItemView extends BaseNotificationItemView {
+class EntityRemovedNotificationItemView extends BaseNotificationItemView {
 
     messageName = 'entityRemoved'
 
@@ -59,4 +59,4 @@ class EmailRemovedNotificationItemView extends BaseNotificationItemView {
     }
 }
 
-export default EmailRemovedNotificationItemView;
+export default EntityRemovedNotificationItemView;


### PR DESCRIPTION
### Summary
This PR fixes an incorrect class name in the notification view.

### What has been changed
- Renamed `EmailRemovedNotificationItemView` → `EntityRemovedNotificationItemView` in the notification item view file.
- The previous name was misleading, since this view is used for *entity removal* notifications, not email removal.

### Why
The wrong class name could cause confusion for developers and reduce code readability.