### PR TITLE
Fix Htmlizer translation for enum fields

### DIFF
--- a/application/Espo/Core/Htmlizer/Htmlizer.php
+++ b/application/Espo/Core/Htmlizer/Htmlizer.php
@@ -391,7 +391,7 @@ class Htmlizer
                         ->get(['entityDefs', $entity->getEntityType(), 'fields', $attribute, 'translation']);
 
                     if ($translationPath) {
-                        $data[$attribute] = $this->language->get($translationPath . '.' . $attribute, $data[$attribute]);
+                        $data[$attribute] = $this->language->get($translationPath . '.' . $data[$keyRaw], $data[$attribute]);
                     }
                 }
 


### PR DESCRIPTION
Using original value of enum option instead of attribute name. Also tested with null.