### PR TITLE
Add value to Item in default case of DefaultDateTimeItemTransformer

### DIFF
--- a/application/Espo/Core/Select/Where/DefaultDateTimeItemTransformer.php
+++ b/application/Espo/Core/Select/Where/DefaultDateTimeItemTransformer.php
@@ -511,6 +511,7 @@ class DefaultDateTimeItemTransformer implements DateTimeItemTransformer
 
             default:
                 $where['type'] = $type;
+                $where['value'] = $value;
         }
 
         return Item::fromRaw($where);


### PR DESCRIPTION
In the default datetime item transformer, a `default` case handles custom types by returning a new `Item`:
```php
            default:
                $where['type'] = $type;
```
The ItemGeneralConverter than instantiates a custom converter, which works fine. However, this system does not work when the `value` field is needed by the custom converter. To fix that, the default case in `DefaultDateTimeItemTransformer` needs to return `$value` as part of the `Item`:
```php
            default:
                $where['type'] = $type;
                $where['value'] = $value;
```
As far as I can tell, this change has not impacted any other filter types, and it does not change the call stack in any way.