### PR TITLE
fix clientDefs schema 

### DIFF
--- a/schema/metadata/clientDefs.json
+++ b/schema/metadata/clientDefs.json
@@ -527,8 +527,9 @@
                         "description": "Attributes to carry over to a related record when creating. Mapping Parent => Related."
                     },
                     "buttonList": {
-                        "type": "object",
-                        "properties": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
                             "name": {
                                 "type": "string",
                                 "description": "A name."


### PR DESCRIPTION
I changed the `buttonList` type from an object to an array, because it should match the type of `actionList`.

https://github.com/espocrm/espocrm/blob/9.1.9/client/src/views/record/panels-container.js#L53-L54