### PR TITLE
Add getSecret formula function

### DIFF
--- a/application/Espo/Core/Formula/Functions/ExtGroup/SecretGroup/GetType.php
+++ b/application/Espo/Core/Formula/Functions/ExtGroup/SecretGroup/GetType.php
@@ -27,7 +27,7 @@
  * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
  ************************************************************************/
 
-namespace Espo\Core\Formula\Functions\UtilGroup;
+namespace Espo\Core\Formula\Functions\ExtGroup\SecretGroup;
 
 use Espo\Core\Formula\EvaluatedArgumentList;
 use Espo\Core\Formula\Exceptions\BadArgumentType;
@@ -35,7 +35,7 @@ use Espo\Core\Formula\Exceptions\TooFewArguments;
 use Espo\Core\Formula\Func;
 use Espo\Tools\AppSecret\SecretProvider;
 
-class GetSecretType implements Func
+class GetType implements Func
 {
     public function __construct(private SecretProvider $secretProvider) {}
 

--- a/application/Espo/Core/Formula/Functions/UtilGroup/GetSecretType.php
+++ b/application/Espo/Core/Formula/Functions/UtilGroup/GetSecretType.php
@@ -39,7 +39,7 @@ class GetSecretType implements Func
 {
     public function __construct(private SecretProvider $secretProvider) {}
 
-    public function process(EvaluatedArgumentList $arguments): string
+    public function process(EvaluatedArgumentList $arguments): mixed
     {
         if (count($arguments) < 1) {
             throw TooFewArguments::create(1);

--- a/application/Espo/Core/Formula/Functions/UtilGroup/GetSecretType.php
+++ b/application/Espo/Core/Formula/Functions/UtilGroup/GetSecretType.php
@@ -1,0 +1,62 @@
+<?php
+/************************************************************************
+ * This file is part of EspoCRM.
+ *
+ * EspoCRM – Open Source CRM application.
+ * Copyright (C) 2014-2025 EspoCRM, Inc.
+ * Website: https://www.espocrm.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
+ ************************************************************************/
+
+namespace Espo\Core\Formula\Functions\UtilGroup;
+
+use Espo\Core\Formula\EvaluatedArgumentList;
+use Espo\Core\Formula\Exceptions\BadArgumentType;
+use Espo\Core\Formula\Exceptions\TooFewArguments;
+use Espo\Core\Formula\Func;
+use Espo\Tools\AppSecret\SecretProvider;
+
+class GetSecretType implements Func
+{
+    public function __construct(private SecretProvider $secretProvider) {}
+
+    public function process(EvaluatedArgumentList $arguments): string
+    {
+        if (count($arguments) < 1) {
+            throw TooFewArguments::create(1);
+        }
+
+        $string = $arguments[0];
+
+        if (!is_string($string)) {
+            throw BadArgumentType::create(1, 'string');
+        }
+
+        $result = $this->secretProvider->get($string);
+
+        if ($result === null) {
+            return false;
+        }
+
+        return $result;
+    }
+}

--- a/application/Espo/Core/Formula/Functions/UtilGroup/GetSecretType.php
+++ b/application/Espo/Core/Formula/Functions/UtilGroup/GetSecretType.php
@@ -51,12 +51,6 @@ class GetSecretType implements Func
             throw BadArgumentType::create(1, 'string');
         }
 
-        $result = $this->secretProvider->get($string);
-
-        if ($result === null) {
-            return false;
-        }
-
-        return $result;
+        return $this->secretProvider->get($string);
     }
 }

--- a/application/Espo/Resources/metadata/app/formula.json
+++ b/application/Espo/Resources/metadata/app/formula.json
@@ -411,11 +411,6 @@
             "returnType": "string"
         },
         {
-            "name": "util\\getSecret",
-            "insertText": "util\\getSecret(STRING)",
-            "returnType": "string"
-        },
-        {
             "name": "object\\create",
             "insertText": "object\\create()",
             "returnType": "object"
@@ -636,6 +631,11 @@
             "insertText": "ext\\oauth\\getAccessToken(ID)",
             "returnType": "string",
             "unsafe": true
+        },
+        {
+            "name": "ext\\appSecret\\get",
+            "insertText": "ext\\appSecret\\get(STRING)",
+            "returnType": "string"
         }
     ],
     "functionClassNameMap": {
@@ -647,9 +647,9 @@
         "ext\\acl\\checkScope": "Espo\\Core\\Formula\\Functions\\ExtGroup\\AclGroup\\CheckScopeType",
         "ext\\acl\\getLevel": "Espo\\Core\\Formula\\Functions\\ExtGroup\\AclGroup\\GetLevelType",
         "ext\\acl\\getPermissionLevel": "Espo\\Core\\Formula\\Functions\\ExtGroup\\AclGroup\\GetPermissionLevelType",
+        "ext\\appSecret\\get": "Espo\\Core\\Formula\\Functions\\ExtGroup\\SecretGroup\\GetType",
         "util\\base64Encode": "Espo\\Core\\Formula\\Functions\\UtilGroup\\Base64EncodeType",
         "util\\base64Decode": "Espo\\Core\\Formula\\Functions\\UtilGroup\\Base64DecodeType",
-        "util\\getSecret": "Espo\\Core\\Formula\\Functions\\UtilGroup\\GetSecretType",
         "ext\\oauth\\getAccessToken": "Espo\\Core\\Formula\\Functions\\ExtGroup\\OauthGroup\\GetAccessTokenType"
     }
 }

--- a/application/Espo/Resources/metadata/app/formula.json
+++ b/application/Espo/Resources/metadata/app/formula.json
@@ -411,6 +411,11 @@
             "returnType": "string"
         },
         {
+            "name": "util\\getSecret",
+            "insertText": "util\\getSecret(STRING)",
+            "returnType": "string"
+        },
+        {
             "name": "object\\create",
             "insertText": "object\\create()",
             "returnType": "object"
@@ -644,6 +649,7 @@
         "ext\\acl\\getPermissionLevel": "Espo\\Core\\Formula\\Functions\\ExtGroup\\AclGroup\\GetPermissionLevelType",
         "util\\base64Encode": "Espo\\Core\\Formula\\Functions\\UtilGroup\\Base64EncodeType",
         "util\\base64Decode": "Espo\\Core\\Formula\\Functions\\UtilGroup\\Base64DecodeType",
+        "util\\getSecret": "Espo\\Core\\Formula\\Functions\\UtilGroup\\GetSecretType",
         "ext\\oauth\\getAccessToken": "Espo\\Core\\Formula\\Functions\\ExtGroup\\OauthGroup\\GetAccessTokenType"
     }
 }


### PR DESCRIPTION
### Problem

Currently, when reading secrets via formula scripts, only the **encrypted value** of a secret is returned. For example:

```php
$secretValue = null;

$secretId = record\findOne('AppSecret', null, null, 'name', 'SECRET_NAME');

if ($secretId) {
    $secretValue = record\attribute('AppSecret', $secretId, 'value');
}
```

This makes it impossible to directly use the actual secret value inside formula logic or workflow http request payload.

---

### Solution

Introduce a new formula function:

```php
util\getSecret(secretName)
```

This function returns the **decrypted value** of the secret, making it much easier to work with secrets in formula scripts.

---

### Example Usage (Formula Sandbox)

```php
$secretValue = null;

$secretId = record\findOne('AppSecret', null, null, 'name', 'test');

if ($secretId) {
    $secretValue = record\attribute('AppSecret', $secretId, 'value');
}

output\printLine($secretValue); // Encrypted value

$actualSecretValue = util\getSecret('test');

output\printLine($actualSecretValue); // Decrypted value
```