### PR TITLE
statusField: Only storable enum

### DIFF
--- a/client/src/views/admin/entity-manager/edit.js
+++ b/client/src/views/admin/entity-manager/edit.js
@@ -184,7 +184,9 @@ class EntityManagerEditView extends View {
                         return;
                     }
 
-                    if (fieldDefs[item].type === 'enum') {
+                    if (fieldDefs[item].type === 'enum' &&
+                        (!('notSortable' in fieldDefs[item]) || fieldDefs[item].notSortable === false)
+                    ) {
                         return true;
                     }
                 })

--- a/client/src/views/admin/entity-manager/edit.js
+++ b/client/src/views/admin/entity-manager/edit.js
@@ -185,7 +185,7 @@ class EntityManagerEditView extends View {
                     }
 
                     if (fieldDefs[item].type === 'enum' &&
-                        (!('notSortable' in fieldDefs[item]) || fieldDefs[item].notSortable === false)
+                        (!('notStorable' in fieldDefs[item]) || fieldDefs[item].notStorable === false)
                     ) {
                         return true;
                     }

--- a/client/src/views/admin/entity-manager/edit.js
+++ b/client/src/views/admin/entity-manager/edit.js
@@ -184,9 +184,9 @@ class EntityManagerEditView extends View {
                         return;
                     }
 
-                    if (fieldDefs[item].type === 'enum' &&
-                        (!('notStorable' in fieldDefs[item]) || fieldDefs[item].notStorable === false)
-                    ) {
+                    const isNotStorable = !('notStorable' in fieldDefs[item]) || fieldDefs[item].notStorable === false;
+
+                    if (fieldDefs[item].type === 'enum' && isNotStorable) {
                         return true;
                     }
                 })


### PR DESCRIPTION
This pr is to allow statusField to be filled with only storable enum fields of the entitytype. 

Currently if you go to contact and edit the entity and choose a statsuField (Opportunity Role || Acceptance Status (Call) || Acceptance Status (Meeting)) end then enable kanban then kanban would appear first time but as soon as you change something in contact and try to view kanban - it is empty. The reason is that Opportunity Role is not storable field. 

I hope this is clear. 

Thanks 