### PR TITLE
Only run rmdir() when not is_link()

### DIFF
--- a/application/Espo/Core/Utils/File/Manager.php
+++ b/application/Espo/Core/Utils/File/Manager.php
@@ -701,7 +701,7 @@ class Manager
         $result = true;
 
         foreach ($dirPaths as $dirPath) {
-            if (is_dir($dirPath) && is_writable($dirPath)) {
+            if (is_dir($dirPath) && is_writable($dirPath) && is_link($dirPath) === false) {
                 $result &= rmdir($dirPath);
             }
         }


### PR DESCRIPTION
This is a suggested fix for #3493