### PR TITLE
Fix issue 3505 - Espo\Tools\DataPrivacy\Erasor tries to access protected property id on entities

### DIFF
--- a/application/Espo/Tools/DataPrivacy/Erasor.php
+++ b/application/Espo/Tools/DataPrivacy/Erasor.php
@@ -114,7 +114,7 @@ class Erasor implements
                         $this->emailAddressAccessChecker
                             ->checkEdit($this->user, $emailAddress, $entity)
                     ) {
-                        $emailAddress->set(Field::NAME, 'ERASED:' . $emailAddress->id);
+                        $emailAddress->set(Field::NAME, 'ERASED:' . $emailAddress->getId());
                         $emailAddress->set('optOut', true);
                         $this->entityManager->saveEntity($emailAddress);
                     }
@@ -132,7 +132,7 @@ class Erasor implements
                         $this->phoneNumberAccessChecker
                             ->checkEdit($this->user, $phoneNumber, $entity)
                     ) {
-                        $phoneNumber->set(Field::NAME, 'ERASED:' . $phoneNumber->id);
+                        $phoneNumber->set(Field::NAME, 'ERASED:' . $phoneNumber->getId());
 
                         $this->entityManager->saveEntity($phoneNumber);
                     }


### PR DESCRIPTION
This fixes the issue https://github.com/espocrm/espocrm/issues/3505

Sorry, for maybe selecting the wrong branch.