### PR TITLE
Fix Branch : correct typo in WebSocket schema descriptionTypo websocket schema 

### DIFF
--- a/schema/metadata/app/webSocket.json
+++ b/schema/metadata/app/webSocket.json
@@ -19,7 +19,7 @@
                     },
                     "accessCheckCommand": {
                         "type": "string",
-                        "description": "A console command that will be used to check whether a topic is allowed for a user when they attempting to subscribe. Patameter placeholders starts with the colon :. The userId parameter contains a user ID. If access checking is not needed, omit this parameter."
+                        "description": "A console command that will be used to check whether a topic is allowed for a user when they attempting to subscribe. Parameter placeholders starts with the colon :. The userId parameter contains a user ID. If access checking is not needed, omit this parameter."
                     }
                 }
             }


### PR DESCRIPTION
This pull request fixes a minor typo in the WebSocket schema description:

Changed 'patameter' to 'parameter'.
No functional changes were made. Purely a documentation correction in fix branch.