### PR TITLE
Fix missing value of entityType variable

### DIFF
--- a/client/src/views/modals/related-list.js
+++ b/client/src/views/modals/related-list.js
@@ -253,7 +253,7 @@ class RelatedListModalView extends ModalView {
         this.$header.append(
             title ||
             $('<span>').text(
-                this.getLanguage().translate(this.link, 'links', this.entityType)
+                this.getLanguage().translate(this.link, 'links', this.scope)
             )
         );
 


### PR DESCRIPTION
`this.entityType` is not being initialized and remains undefined.

After reviewing the current view and its parent components, I found no logic that sets or propagates a value for this property.