### PR TITLE
fix required field validation

### DIFF
--- a/application/Espo/Core/FieldValidation/FieldValidationManager.php
+++ b/application/Espo/Core/FieldValidation/FieldValidationManager.php
@@ -128,7 +128,7 @@ class FieldValidationManager
                 !$entityDefs->tryGetField($field)?->getParam('forceValidation') &&
                 !$this->isFieldSetInData($entityType, $field, $data)
             ) {
-                if (!$this->hasRequiredLogic($entityType, $field)) {
+                if (!$this->hasRequiredLogic($entityType, $field) && !$this->hasRequiredFieldParam($entityType, $field)) {
                     continue;
                 }
 
@@ -500,5 +500,10 @@ class FieldValidationManager
     private function hasRequiredLogic(string $entityType, string $field): bool
     {
         return (bool) $this->metadata->get("logicDefs.$entityType.fields.$field.required");
+    }
+
+    private function hasRequiredFieldParam(string $entityType, string $field): bool
+    {
+        return (bool) $this->metadata->get("entityDefs.$entityType.fields.$field.required");
     }
 }


### PR DESCRIPTION
This PR fixes incorrect validation logic for fields whose required flag is changed after records already exist.

If a field is made not required, records are created, and then the field is made required again, EspoCRM allows updating other fields via inline edit while bypassing validation of the newly required field.
This results in records being saved in an invalid state.

**Steps to reproduce**
1. In **Entity Manager**, make a field **not required**.
2. Create a record of this entity type.
3. Change the same field back to **required** in **Entity Manager**.
4. Open the previously created record.
5. Edit any _other_ field using **inline edit** (do not touch the required field).
6. Save — the update succeeds even though the required field is empty.