### PR TITLE
Fix error "Unknown column 'api' in 'field list'" on mass relate

### DIFF
--- a/application/Espo/Core/Record/Service.php
+++ b/application/Espo/Core/Record/Service.php
@@ -1303,7 +1303,7 @@ class Service implements Crud,
 
             $this->getRepository()
                 ->getRelation($entity, $link)
-                ->relate($foreignEntity, [SaveOption::API => true]);
+                ->relate($foreignEntity, null, [SaveOption::API => true]);
 
             $countRelated++;
         }


### PR DESCRIPTION
I enabled mass linking on a custom relationship for a custom entity (CallList → Contacts). When I used “Select all”  in the contacts popup, the request hit the massLink url and failed with this error: 
  
[2026-01-16 06:52:17] CRITICAL: (42S22) SQLSTATE[42S22]: Column not found: 1054 Unknown column 'api' in 'field list' :: POST /CallList/6969de2d37138f147/contacts :: /var/www/html/application/Espo/ORM/Executor/DefaultSqlExecutor.php(77)

Steps to reproduce:

1. Create two entities with a many‑to‑many relationship (any entity with a relationship panel that supports mass select).
2. Ensure the relationship allows mass link and the user does not have ALL‑level access to the foreign entity (so massLink uses the per‑record fallback).
3. Open the parent record, open the relationship panel, click “Select”, use “Select all” (mass relate), and confirm.
4. Observe 500 error with SQL Unknown column 'api' in field list (relation table has no api column).