### PR TITLE
Fix undefined stdClass property warnings when viewing notifications

### DIFF
--- a/application/Espo/Tools/Notification/RecordService.php
+++ b/application/Espo/Tools/Notification/RecordService.php
@@ -472,12 +472,14 @@ class RecordService
 
     private function prepareSetFields(Notification $entity): void
     {
-        if ($entity->getRelated() && $entity->getData()?->relatedName) {
-            $entity->set('relatedName', $entity->getData()->relatedName);
+        $data = $entity->getData();
+
+        if ($entity->getRelated() && $data && isset($data->relatedName)) {
+            $entity->set('relatedName', $data->relatedName);
         }
 
-        if ($entity->getCreatedBy() && $entity->getData()?->createdByName) {
-            $entity->set('createdByName', $entity->getData()->createdByName);
+        if ($entity->getCreatedBy() && $data && isset($data->createdByName)) {
+            $entity->set('createdByName', $data->createdByName);
         }
     }
 }


### PR DESCRIPTION
Fixes E_WARNING "Undefined property: stdClass::$relatedName / $createdByName"
triggered when opening notifications via the bell icon.

Notification::getData() returns stdClass and may not contain these
properties. Access is now guarded with isset() to prevent warnings.