### PR TITLE
Fix attachment MIME type detection for non-image file types

### DIFF
--- a/application/Espo/Core/Mail/Parsers/MailMimeParser.php
+++ b/application/Espo/Core/Mail/Parsers/MailMimeParser.php
@@ -58,6 +58,27 @@ class MailMimeParser implements Parser
         'png' => 'image/png',
         'gif' => 'image/gif',
         'webp' => 'image/webp',
+        'pdf' => 'application/pdf',
+        'doc' => 'application/msword',
+        'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'xls' => 'application/vnd.ms-excel',
+        'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'ppt' => 'application/vnd.ms-powerpoint',
+        'pptx' => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'odt' => 'application/vnd.oasis.opendocument.text',
+        'ods' => 'application/vnd.oasis.opendocument.spreadsheet',
+        'csv' => 'text/csv',
+        'txt' => 'text/plain',
+        'html' => 'text/html',
+        'htm' => 'text/html',
+        'xml' => 'application/xml',
+        'zip' => 'application/zip',
+        'gz' => 'application/gzip',
+        'eml' => 'message/rfc822',
+        'svg' => 'image/svg+xml',
+        'bmp' => 'image/bmp',
+        'tif' => 'image/tiff',
+        'tiff' => 'image/tiff',
     ];
 
     private ?WrappeeParser $parser = null;
@@ -434,9 +455,9 @@ class MailMimeParser implements Parser
             return null;
         }
 
-        $ext = explode('.', $filename)[1] ?? null;
+        $ext = pathinfo($filename, PATHINFO_EXTENSION);
 
-        if (!$ext) {
+        if ($ext === '') {
             return null;
         }
 


### PR DESCRIPTION
I noticed that sometimes attachments have the wrong mime type (for example, a .pdf will have text/html and so on), causing them to be downloaded instead of opened in-browser. I tracked this down and here is the fix for that.

## Summary

- **Extended `$extMimeTypeMap`** in `MailMimeParser` with 22 common document, archive and media MIME types (pdf, doc/docx, xls/xlsx, ppt/pptx, odt, ods, csv, txt, html, xml, zip, gz, eml, svg, bmp, tif/tiff). Previously only 5 image types were mapped, causing attachments sent as `application/octet-stream` (common with Lotus Notes and other legacy mail clients) to be stored with a NULL type — which made them download instead of opening inline.

- **Fixed `getAttachmentFilenameExtension()`** which used `explode('.', $filename)[1]` to extract the extension. This returns the part after the *first* dot, not the last — so `report.2024.pdf` would return `2024` instead of `pdf`. Replaced with `pathinfo($filename, PATHINFO_EXTENSION)` which correctly extracts the final extension.

## How to reproduce

1. Receive an email with a PDF attachment from a client that sends `Content-Type: application/octet-stream` (e.g. Lotus Notes / HCL Domino)
2. Try to open the attachment in EspoCRM — it downloads instead of opening inline in the browser
3. Check the `attachment` table — the `type` column is NULL for the affected attachment