### PR TITLE
Fix: scheduled email stream note missing user attribution

### DIFF
--- a/application/Espo/Tools/Stream/Service.php
+++ b/application/Espo/Tools/Stream/Service.php
@@ -558,10 +558,18 @@ class Service
         if (!$user->isSystem()) {
             $person = $user;
         } else {
-            $from = $email->getFromAddress();
+            $createdBy = $email->getCreatedBy();
 
-            if ($from) {
-                $person = $this->getEmailAddressRepository()->getEntityByAddress($from);
+            if ($createdBy) {
+                $person = $this->entityManager->getEntityById(User::ENTITY_TYPE, $createdBy->getId());
+            }
+
+            if (!$person) {
+                $from = $email->getFromAddress();
+
+                if ($from) {
+                    $person = $this->getEmailAddressRepository()->getEntityByAddress($from);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #3541

When emails are sent via the **Send Later** (scheduled) feature, the stream note on the related entity shows "sent email" without the user name. This happens because the `SendScheduledEmails` job runs in system user context, and the fallback logic that tries to find a person by the email's FROM address fails for group email accounts.

## Changes

In `application/Espo/Tools/Stream/Service.php`, method `noteEmailSent()`:

- Added a `getCreatedBy()` lookup as the **first fallback** when running in system context
- This resolves the user who originally composed/scheduled the email
- The existing FROM address lookup is preserved as a second fallback

## Before
```
"sent email" (no user name)
```

## After
```
"John Smith sent email" (with clickable link to user)
```

## Test plan
1. Create a Lead/Contact with an email address
2. Compose an email from that entity using "Send Later"
3. Wait for the scheduled job to send it
4. Verify the stream note shows the correct user name