### PR TITLE
Added a parameter to disable automatic following for assigned users

### DIFF
--- a/application/Espo/Tools/Stream/HookProcessor.php
+++ b/application/Espo/Tools/Stream/HookProcessor.php
@@ -364,6 +364,9 @@ class HookProcessor
     {
         $entityType = $entity->getEntityType();
 
+        $followAssignedUser = $this->metadata->get(['streamDefs', $entityType,
+            'followAssignedUser']) ?? true;
+
         $multipleField = $this->metadata->get(['streamDefs', $entityType, 'followingUsersField']) ??
             Field::ASSIGNED_USERS;
 
@@ -397,7 +400,7 @@ class HookProcessor
             );
         }
 
-        if ($assignedUserId && !in_array($assignedUserId, $userIdList)) {
+        if ($assignedUserId && !in_array($assignedUserId, $userIdList) && $followAssignedUser) {
             $userIdList[] = $assignedUserId;
         }
 
@@ -490,7 +493,10 @@ class HookProcessor
     {
         $assignedUserId = $entity->get('assignedUserId');
 
-        if (!$assignedUserId) {
+        $followAssignedUser = $this->metadata->get(['streamDefs', $entity->getEntityType(),
+            'followAssignedUser']) ?? true;
+
+        if (!$assignedUserId || !$followAssignedUser) {
             $this->service->noteAssign($entity, $options);
 
             return;


### PR DESCRIPTION
It is currently not possible to prevent assigned users from following records of a specific entity when the stream is enabled. This is problematic for many use cases.

Many discussions and workarounds have been posted to the forums. E.g.:
* https://forum.espocrm.com/forum/general/120778-disable-auto-follow-for-assigned-users
* https://forum.espocrm.com/forum/general/90302-create-entity-with-assigned-user-and-delete-followers-by-api#post90311

Removing followers _after_ creation is not a viable workaround when the number of records is large. For example, my users are assigned to hundreds of records every day, which generates hundreds or thousands of notifications. Automatically following assigned records is a huge problem for my organization because the number of notifications causes important notifications to be missed. My current workaround is to delete notifications after creation, which usually works, but it is not error-proof and it also creates unnecessary burden on the backend and database.

This PR introduces an optional flag that allows developers to prevent assigned users from automatically following records. It does not change the default behavior.

There is a [corresponding PR](https://github.com/espocrm/documentation/pull/937) for the documentation.