### PR TITLE
Portal with non-default id: password-reset link causes infinite 301 r…

### DIFF
--- a/application/Espo/Core/Portal/Utils/Url.php
+++ b/application/Espo/Core/Portal/Utils/Url.php
@@ -141,18 +141,19 @@ class Url
 
     public static function getRedirectUrlWithTrailingSlash(): ?string
     {
-        $uri = $_SERVER['REQUEST_URI'];
+        $uri = $_SERVER['REQUEST_URI'] ?? '';
+        $path = explode('?', $uri, 2)[0];
 
-        if ($uri === '' || $uri === '/' || str_ends_with($uri, '/')) {
+        if ($path === '' || $path === '/' || str_ends_with($path, '/')) {
             return null;
         }
 
-        $output = $uri . '/';
+        $output = $path . '/';
 
         $queryString = $_SERVER['QUERY_STRING'] ?? null;
 
         if ($queryString !== null && $queryString !== '') {
-            $output .= '?' . $_SERVER['QUERY_STRING'];
+            $output .= '?' . $queryString;
         }
 
         return $output;


### PR DESCRIPTION
Portal with non-default id: password-reset link causes infinite 301 redirect loop that doubles the query string (414 Request-URI Too Long)

Steps to reproduce
Create a Portal that is not the default portal (so that Portal::loadUrlField() produces a URL of the form {siteUrl}/portal/{portalId}/ see [#Portal.php:46‑74](https://github.com/espocrm/espocrm/blob/master/application/Espo/Repositories/Portal.php#L46-L74)).
Add a Portal user to it and trigger a password reset (Forgot Password → enter email; or admin → "Send Password Change Link").
Open the link from the resulting email, for example: 

> https://example.com/portal/{portalId}/?entryPoint=changePassword&id={token}


Expected
The change-password form is rendered (as it is when the URL is https://example.com/portal/?entryPoint=changePassword&id={token} for the default portal).

Actual
The browser follows a cascade of 301 responses. Each hop doubles the query string. Within ~6 hops the URL contains 64 copies of ?entryPoint=changePassword&id={token} and the server returns 414 Request-URI Too Long.

Example after 3 hops:


> /portal/{portalId}/?entryPoint=changePassword&id={token}/?entryPoint=changePassword&id={token}/?entryPoint=changePassword&id={token}/?entryPoint=changePassword&id={token}

Root cause
Url::getRedirectUrlWithTrailingSlash() in [application/Espo/Core/Portal/Utils/Url.php:142‑159](https://github.com/espocrm/espocrm/blob/master/application/Espo/Core/Portal/Utils/Url.php#L142-L159) uses $_SERVER['REQUEST_URI'] without first stripping the query string:

str_ends_with($uri, '/') checks the end of the query string, not the path, so the guard at line 146 fails even when the path already ends with /.
$output = $uri . '/' places the slash after the query string.
QUERY_STRING is then re-appended, producing a malformed redirect that the next request round-trips back into this same function, each iteration doubles the fragment.
The sibling helpers in the same class: detectIsInPortalDir() (line 114) and detectIsInPortalWithId() (line 129) already use explode('?', $_SERVER['REQUEST_URI'])[0] before inspecting the path. getRedirectUrlWithTrailingSlash() is inconsistent with them.

Proposed fix
```
public static function getRedirectUrlWithTrailingSlash(): ?string
{
    $uri = $_SERVER['REQUEST_URI'] ?? '';
    $path = explode('?', $uri, 2)[0];

    if ($path === '' || $path === '/' || str_ends_with($path, '/')) {
        return null;
    }

    $output = $path . '/';

    $queryString = $_SERVER['QUERY_STRING'] ?? null;

    if ($queryString !== null && $queryString !== '') {
        $output .= '?' . $queryString;
    }

    return $output;
}
```

An even easier fix may be to just redirect the user to https://example.com/portal/?entryPoint=changePassword&id={token}  instead of appending the portalId