### PR TITLE
Fix enum OpenAPI option handling when options are missing

### DIFF
--- a/application/Espo/Tools/OpenApi/Util/EnumOptionsProvider.php
+++ b/application/Espo/Tools/OpenApi/Util/EnumOptionsProvider.php
@@ -59,6 +59,10 @@ class EnumOptionsProvider
             $this->metadata->get($path) :
             $fieldDefs->getParam('options');
 
+        if (!is_array($optionList)) {
+            return null;
+        }
+
         return $optionList;
     }
 }


### PR DESCRIPTION
This PR fixes an error in `EnumOptionsProvider::get()` when a field has `type: "enum"` but does not define `options`, `optionsPath`, or a resolvable `optionsReference`.

In this case causes the code to fail with an error and /OpenApi not load.

#### Example

```json
"electronicAddressScheme": {
    "type": "enum",
    "maxLength": 4,
    "view": "sales:views/fields/electronic-address-scheme",
    "validatorClassNameList": [
        "Espo\\Modules\\Sales\\FieldValidators\\Account\\ElectronicAddressScheme\\Valid"
    ],
    "audited": true
}
```

#### What changed

`EnumOptionsProvider::get()` now validates the resolved value before returning it:

```php
if (!is_array($optionList)) {
    return null;
}
```
