### PR TITLE
LDAP: add local auth fallback for regular users

### DIFF
--- a/application/Espo/Core/Authentication/Ldap/LdapLogin.php
+++ b/application/Espo/Core/Authentication/Ldap/LdapLogin.php
@@ -154,6 +154,8 @@ class LdapLogin implements Login
 
         $ldapClient = $this->getLdapClient();
 
+        $fallbackToLocal = (bool) $this->config->get('ldapFallbackToLocalAuth', false);
+
         /* Login LDAP system user (ldapUsername, ldapPassword) */
         try {
             $ldapClient->bind();
@@ -167,13 +169,15 @@ class LdapLogin implements Login
 
             /** @var string $username */
 
-            $adminUser = $this->adminLogin($username, $password);
+            $adminUser = $fallbackToLocal
+                ? $this->localLogin($username, $password)
+                : $this->adminLogin($username, $password);
 
             if (!isset($adminUser)) {
                 return Result::fail();
             }
 
-            $this->log->info("LDAP: Administrator '{username}' was logged in by Espo method.", [
+            $this->log->info("LDAP: User '{username}' was logged in by local Espo method (LDAP server unreachable).", [
                 'username' => $username,
             ]);
         }
@@ -197,13 +201,15 @@ class LdapLogin implements Login
                     'username' => $username,
                 ]);
 
-                $adminUser = $this->adminLogin($username, $password);
+                $adminUser = $fallbackToLocal
+                    ? $this->localLogin($username, $password)
+                    : $this->adminLogin($username, $password);
 
                 if (!isset($adminUser)) {
                     return Result::fail();
                 }
 
-                $this->log->info("LDAP: Administrator '{username}' was logged in by Espo method.", [
+                $this->log->info("LDAP: User '{username}' was logged in by local Espo method (not found in LDAP).", [
                     'username' => $username,
                 ]);
             }
@@ -221,7 +227,19 @@ class LdapLogin implements Login
                     'message' => $e->getMessage(),
                 ]);
 
-                return Result::fail();
+                if ($fallbackToLocal) {
+                    $adminUser = $this->localLogin($username, $password);
+
+                    if (!isset($adminUser)) {
+                        return Result::fail();
+                    }
+
+                    $this->log->info("LDAP: User '{username}' was logged in by local Espo method (LDAP credentials rejected).", [
+                        'username' => $username,
+                    ]);
+                } else {
+                    return Result::fail();
+                }
             }
         }
 
@@ -314,6 +332,27 @@ class LdapLogin implements Login
                 'userName' => $username,
             ])
             ->findOne();
+    }
+
+    private function localLogin(string $username, #[SensitiveParameter] string $password): ?User
+    {
+        $user = $this->entityManager
+            ->getRDBRepositoryByClass(User::class)
+            ->where([
+                'userName' => $username,
+                'type!=' => [User::TYPE_API, User::TYPE_SYSTEM, User::TYPE_SUPER_ADMIN],
+            ])
+            ->findOne();
+
+        if (!$user) {
+            return null;
+        }
+
+        if (!$this->passwordHash->verify($password, $user->getPassword())) {
+            return null;
+        }
+
+        return $user;
     }
 
     private function adminLogin(string $username, #[SensitiveParameter] string $password): ?User

--- a/application/Espo/Resources/defaults/config.php
+++ b/application/Espo/Resources/defaults/config.php
@@ -280,6 +280,7 @@ return [
     'ldapUserPhoneNumberAttribute' => 'telephoneNumber',
     'ldapUserObjectClass' => 'person',
     'ldapPortalUserLdapAuth' => false,
+    'ldapFallbackToLocalAuth' => false,
     'passwordGenerateLength' => 10,
     'passwordStrengthLength' => null,
     'passwordStrengthLetterCount' => null,


### PR DESCRIPTION
Closes #1948.

Currently, when LDAP authentication is enabled, only admin users can fall back to local Espo authentication (when the LDAP server is unreachable or the user is not found in LDAP). Regular users — such as contractors and partners who are not present in the LDAP/AD tree — have no fallback at all. There is also no fallback of any kind when LDAP accepts a user's DN but rejects the password bind.

This PR adds an opt-in `ldapFallbackToLocalAuth` config flag (default: `false`, so existing behaviour is fully preserved). When enabled:

- Any non-API, non-system user with a local Espo password can authenticate via local auth if LDAP is unavailable.
- The same fallback applies when the user is not found in LDAP (the primary use case from #1948 — users such as contractors not present in AD).
- A new fallback covers the LDAP password-bind failure case, which previously had no fallback even for admins.

The existing `adminLogin()` method is left untouched. A new `localLogin()` method handles the broader user scope, with the same type exclusions as the downstream user lookup (`TYPE_API`, `TYPE_SYSTEM`, `TYPE_SUPER_ADMIN`).