### PR TITLE
Add notification sounds for new notifications

### DIFF
--- a/application/Espo/Resources/defaults/config.php
+++ b/application/Espo/Resources/defaults/config.php
@@ -268,6 +268,7 @@ return [
     'auth2FAInPortal' => false,
     'personNameFormat' => 'firstLast',
     'newNotificationCountInTitle' => false,
+    'notificationSoundsDisabled' => true,
     'pdfEngine' => 'Dompdf',
     'smsProvider' => null,
     'mapProvider' => 'Google',

--- a/application/Espo/Resources/layouts/Settings/notifications.json
+++ b/application/Espo/Resources/layouts/Settings/notifications.json
@@ -3,7 +3,7 @@
         "label": "In-app Notifications",
         "rows": [
             [{"name": "assignmentNotificationsEntityList"}, false],
-            [{"name": "newNotificationCountInTitle"}, false]
+            [{"name": "newNotificationCountInTitle"}, {"name": "notificationSoundsDisabled"}]
         ]
     },
     {

--- a/client/src/views/notification/badge.js
+++ b/client/src/views/notification/badge.js
@@ -108,7 +108,6 @@ class NotificationBadgeView extends View {
         this.addActionHandler('showNotifications', () => this.showNotifications());
 
         this.soundPath = this.getBasePath() + (this.getConfig().get('notificationSound') || this.soundPath);
-        this.notificationSoundsDisabled = this.getConfig().get('notificationSoundsDisabled') ?? true;
         this.useWebSocket = this.webSocketManager.isEnabled();
 
         const clearTimeouts = () => {
@@ -240,7 +239,7 @@ class NotificationBadgeView extends View {
     }
 
     playSound() {
-        if (this.notificationSoundsDisabled) {
+        if (this.getConfig().get('notificationSoundsDisabled') ?? true) {
             return;
         }
 

--- a/client/src/views/notification/badge.js
+++ b/client/src/views/notification/badge.js
@@ -244,30 +244,9 @@ class NotificationBadgeView extends View {
             return;
         }
 
-        const audioElement =
-            /** @type {HTMLAudioElement} */$('<audio>')
-                .attr('autoplay', 'autoplay')
-                .append(
-                    $('<source>')
-                        .attr('src', this.soundPath + '.mp3')
-                        .attr('type', 'audio/mpeg')
-                )
-                .append(
-                    $('<source>')
-                        .attr('src', this.soundPath + '.ogg')
-                        .attr('type', 'audio/ogg')
-                )
-                .append(
-                    $('<embed>')
-                        .attr('src', this.soundPath + '.mp3')
-                        .attr('hidden', 'true')
-                        .attr('autostart', 'true')
-                        .attr('false', 'false')
-                )
-                .get(0);
-
-        audioElement.volume = 0.3;
-        audioElement.play();
+        const audio = new Audio(this.soundPath + '.mp3');
+        audio.volume = 0.3;
+        audio.play().catch(() => {});
     }
 
     /**

--- a/client/src/views/notification/badge.js
+++ b/client/src/views/notification/badge.js
@@ -108,7 +108,7 @@ class NotificationBadgeView extends View {
         this.addActionHandler('showNotifications', () => this.showNotifications());
 
         this.soundPath = this.getBasePath() + (this.getConfig().get('notificationSound') || this.soundPath);
-        this.notificationSoundsDisabled = true;
+        this.notificationSoundsDisabled = this.getConfig().get('notificationSoundsDisabled') ?? true;
         this.useWebSocket = this.webSocketManager.isEnabled();
 
         const clearTimeouts = () => {

--- a/client/src/views/popup-notification.js
+++ b/client/src/views/popup-notification.js
@@ -158,18 +158,9 @@ class PopupNotificationView extends View {
             return;
         }
 
-        const html =
-            '<audio autoplay="autoplay">' +
-            '<source src="' + this.soundPath + '.mp3" type="audio/mpeg" />' +
-            '<source src="' + this.soundPath + '.ogg" type="audio/ogg" />' +
-            '<embed hidden="true" autostart="true" loop="false" src="' + this.soundPath + '.mp3" />' +
-            '</audio>';
-
-        const $audio = $(html);
-
-        $audio.get(0).volume = 0.3;
-        // noinspection JSUnresolvedReference
-        $audio.get(0).play();
+        const audio = new Audio(this.soundPath + '.mp3');
+        audio.volume = 0.3;
+        audio.play().catch(() => {});
     }
 
     /**

--- a/client/src/views/popup-notification.js
+++ b/client/src/views/popup-notification.js
@@ -85,7 +85,7 @@ class PopupNotificationView extends View {
 
         this.setSelector(containerSelector);
 
-        this.notificationSoundsDisabled = this.getConfig().get('notificationSoundsDisabled');
+        this.notificationSoundsDisabled = this.getConfig().get('notificationSoundsDisabled') ?? true;
 
         this.soundPath = this.getBasePath() +
             (this.getConfig().get('popupNotificationSound') || this.soundPath);

--- a/client/src/views/popup-notification.js
+++ b/client/src/views/popup-notification.js
@@ -85,8 +85,6 @@ class PopupNotificationView extends View {
 
         this.setSelector(containerSelector);
 
-        this.notificationSoundsDisabled = this.getConfig().get('notificationSoundsDisabled') ?? true;
-
         this.soundPath = this.getBasePath() +
             (this.getConfig().get('popupNotificationSound') || this.soundPath);
 
@@ -154,7 +152,7 @@ class PopupNotificationView extends View {
     }
 
     playSound() {
-        if (this.notificationSoundsDisabled) {
+        if (this.getConfig().get('notificationSoundsDisabled') ?? true) {
             return;
         }
 


### PR DESCRIPTION
Enables notification sounds for new in-app notifications.

The repository has partial sound-related scaffolding, but the new-notification badge path hard-codes sounds as disabled, so playback never happens. This PR exposes the setting in admin config and reads it at playback time.