### PR TITLE
Fix OIDC sync clearing user fields when claims are absent from the token

### DIFF
--- a/application/Espo/Core/Authentication/Jwt/Token/Payload.php
+++ b/application/Espo/Core/Authentication/Jwt/Token/Payload.php
@@ -137,6 +137,15 @@ class Payload
         return $this->data[$name] ?? null;
     }
 
+    /**
+     * Whether a claim is present in the payload. Note that a claim explicitly
+     * set to null is considered present, as opposed to an absent claim.
+     */
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->data);
+    }
+
     public static function fromRaw(string $raw): self
     {
         $parsed = null;

--- a/application/Espo/Core/Authentication/Oidc/UserProvider/Sync.php
+++ b/application/Espo/Core/Authentication/Oidc/UserProvider/Sync.php
@@ -118,19 +118,39 @@ class Sync
      */
     private function getUserDataFromToken(UserInfo $userInfo): array
     {
-        return [
-            'emailAddress' => $userInfo->get('email'),
-            'phoneNumber' => $userInfo->get('phone_number'),
-            'emailAddressData' => null,
-            'phoneNumberData' => null,
-            'firstName' => $userInfo->get('given_name'),
-            'lastName' => $userInfo->get('family_name'),
-            'middle_name' => $userInfo->get('middle_name'),
-            'gender' =>
-                in_array($userInfo->get('gender'), ['male', 'female']) ?
-                    ucfirst($userInfo->get('gender') ?? '') :
-                    null,
-        ];
+        $data = [];
+
+        if ($userInfo->has('email')) {
+            $data['emailAddress'] = $userInfo->get('email');
+            $data['emailAddressData'] = null;
+        }
+
+        if ($userInfo->has('phone_number')) {
+            $data['phoneNumber'] = $userInfo->get('phone_number');
+            $data['phoneNumberData'] = null;
+        }
+
+        if ($userInfo->has('given_name')) {
+            $data['firstName'] = $userInfo->get('given_name');
+        }
+
+        if ($userInfo->has('family_name')) {
+            $data['lastName'] = $userInfo->get('family_name');
+        }
+
+        if ($userInfo->has('middle_name')) {
+            $data['middle_name'] = $userInfo->get('middle_name');
+        }
+
+        if ($userInfo->has('gender')) {
+            $gender = $userInfo->get('gender');
+
+            $data['gender'] = in_array($gender, ['male', 'female']) ?
+                ucfirst($gender ?? '') :
+                null;
+        }
+
+        return $data;
     }
 
     /**

--- a/application/Espo/Core/Authentication/Oidc/UserProvider/UserInfo.php
+++ b/application/Espo/Core/Authentication/Oidc/UserProvider/UserInfo.php
@@ -46,4 +46,13 @@ class UserInfo
     {
         return $this->payload->get($name) ?? $this->data[$name] ?? null;
     }
+
+    /**
+     * Whether a claim is present. A claim explicitly set to null is considered
+     * present, as opposed to an absent claim.
+     */
+    public function has(string $name): bool
+    {
+        return $this->payload->has($name) || array_key_exists($name, $this->data);
+    }
 }


### PR DESCRIPTION
Fixes #3638.

When `oidcSync` is enabled, `Sync::getUserDataFromToken()` returned every
field on every login, so any claim absent from the OIDC token (e.g.
`phone_number`, which Cloudron never sends) overwrote the existing EspoCRM
value with `null`. This silently wiped manually-entered phone numbers and
broke our Twilio VoIP routing, which reads the phone off the user profile.

Per the discussion on the issue, this distinguishes "claim absent" from
"claim present but null":

- `Payload::has()` and `UserInfo::has()` report claim presence. `Payload`
  stores all claims via `get_object_vars()`, so `array_key_exists()` is
  reliable and an explicit null still counts as present.
- `getUserDataFromToken()` only includes a field when its claim is present.

Resulting behaviour:

- Claim absent from the token -> field left untouched, existing value preserved.
- Claim present but null/empty -> field set to null, mirroring the provider's erase.

`emailAddressData` / `phoneNumberData` are now only reset when the
corresponding `email` / `phone_number` claim is present, instead of on
every sync.

CLA accepted in espocrm/cla#122.