### PR TITLE
Issue #3678: Fix(postgresql): handle underscore-prefixed array types in DBAL type mapping

### DIFF
--- a/application/Espo/Core/Utils/Database/Dbal/Platforms/PostgresqlPlatform.php
+++ b/application/Espo/Core/Utils/Database/Dbal/Platforms/PostgresqlPlatform.php
@@ -50,6 +50,28 @@ class PostgresqlPlatform extends PostgreSQL100Platform
         return new PostgreSQLSchemaManager($connection, $this);
     }
 
+    public function getDoctrineTypeMapping($dbType)
+    {
+        $dbType = strtolower((string) $dbType);
+
+        return parent::getDoctrineTypeMapping($this->resolvePostgresArrayType($dbType));
+    }
+
+    private function resolvePostgresArrayType(string $dbType): string
+    {
+        if (!str_starts_with($dbType, '_')) {
+            return $dbType;
+        }
+
+        $innerType = substr($dbType, 1);
+
+        if ($innerType === '' || !$this->hasDoctrineTypeMappingFor($innerType)) {
+            return $dbType;
+        }
+
+        return $innerType;
+    }
+
     public function getCreateIndexSQL(Index $index, $table)
     {
         if (!$index->hasFlag('fulltext')) {


### PR DESCRIPTION
Fix(postgresql): handle underscore-prefixed array types in DBAL type mapping

-  fix schema rebuild failure on PostgreSQL (Unknown database type _text requested)
- map underscore-prefixed PostgreSQL types (e.g. _text) to their base mapped type when available
