### PR TITLE
Fix numeric enum detail rendering

### DIFF
--- a/client/src/views/fields/enum-int.js
+++ b/client/src/views/fields/enum-int.js
@@ -39,6 +39,34 @@ class EnumIntFieldView extends EnumFieldView {
 
     validations = []
 
+    setup() {
+        super.setup();
+
+        this.setupNumericTranslatedOptionsFallback();
+    }
+
+    setupNumericTranslatedOptionsFallback() {
+        if (this.translatedOptions !== null) {
+            return;
+        }
+
+        this.translatedOptions = {};
+
+        (this.params.options || []).forEach(value => {
+            if (
+                value === undefined ||
+                value === null ||
+                value === ''
+            ) {
+                return;
+            }
+
+            const valueStr = String(value);
+
+            this.translatedOptions[valueStr] = valueStr;
+        });
+    }
+
     fetch() {
         const raw = this.$element.val();
 


### PR DESCRIPTION
Fixes incorrect detail-mode rendering for numeric enum fields without translations. Previously, **enumInt** and **enumFloat** values could fall through to the generic enum translation path. For values like **5**, this could display a character from the field name instead of the selected numeric value.

Example:
```json
"durationMinutes": {
    "type": "enumInt",
    "options": ["", 5, 30]
}
```

Selecting `5` could render `i` from `durationMinutes[5]` instead of `5`. The fix adds a shared numeric fallback translation map in **EnumIntFieldView**, which is also inherited by **EnumFloatFieldView**.