### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ See installation instructions:
 * [Installation with Docker](https://docs.espocrm.com/administration/docker/installation/)
 * [Installation with Traefik](https://docs.espocrm.com/administration/docker/traefik/)
 
+Or deploy a fully managed instance in one click, no server required:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/espocrm)
+
 ### Bug reporting
 
 Create a [GitHub issue](https://github.com/espocrm/espocrm/issues/new/choose) or post on our [forum](https://forum.espocrm.com/forum/bug-reports).


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added EspoCRM to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the install instructions (links to https://zenith.hosting/host/espocrm).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting