### PR TITLE
Fix navbar overflow width calculation

### DIFF
--- a/client/src/views/site/navbar.js
+++ b/client/src/views/site/navbar.js
@@ -648,6 +648,7 @@ class NavbarSiteView extends View {
         };
 
         const $navbar = $('#navbar .navbar');
+        const navbarRightElement = this.$navbarRight.get(0);
 
         if (window.innerWidth >= smallScreenWidth) {
             $tabs.children('li').each(() => {
@@ -657,8 +658,6 @@ class NavbarSiteView extends View {
             $navbar.css('max-height', 'unset');
             $navbar.css('overflow', 'visible');
         }
-
-        const navbarBaseWidth = this.navbarHeaderElement.clientWidth + this.$navbarRight.width();
 
         const tabCount = this.tabList.length;
 
@@ -672,6 +671,7 @@ class NavbarSiteView extends View {
         const updateWidth = () => {
             const windowWidth = window.innerWidth;
             const moreWidth = $moreLi.width();
+            const navbarRightWidth = navbarRightElement.offsetWidth;
 
             $more.children('li.not-in-more').each(() => {
                 unhideOneTab();
@@ -687,6 +687,8 @@ class NavbarSiteView extends View {
             $more.parent().addClass('hidden');
 
             const headerWidth = this.$el.width();
+            const navbarBaseWidth =
+                this.navbarHeaderElement.clientWidth + navbarRightWidth;
 
             const maxWidth = headerWidth - navbarBaseWidth - moreWidth;
             let width = $tabs.width();


### PR DESCRIPTION
## Summary

Fixes top-navbar layout issue where sometimes navigation items, including the **More** (`…`) menu, could wrap onto a second line and make the navbar approximately twice its intended height.

## Problem

`NavbarSiteView.adjustTop()` calculated the available width using the current width of the right-side navbar container.

During navbar adjustment, the browser’s flex layout could temporarily shrink that container. This produced an underestimated width for the right-side controls and incorrectly indicated that an additional navigation tab would fit.

Once the controls returned to their natural width, the remaining space was insufficient, causing:

- The **More** menu to wrap onto a second line.
- Right-side navbar items to wrap in some cases.
- The navbar height to increase from approximately 42 px to 82 px.
- Inconsistent behavior during initial rendering and window resizing.

## Root Cause

The right-side navbar width was:

- Calculated only once before repeated adjustment passes.
- Measured from a flex container that could be temporarily compressed.
- Not guaranteed to represent the natural combined width of its visible items.

As a result, `adjustTop()` could make its overflow decision using an unstable width.

## Solution

The navbar adjustment now:

- Recalculates the required right-side width during every adjustment pass.
- Measures each visible right-side navbar item using its natural outer width.
- Includes margins when calculating the total required width.
- Uses the stable combined width when determining how many tabs can remain visible.
- Moves additional tabs into the **More** menu when necessary.

This prevents temporary flex shrinking or late-rendered controls from affecting the available-width calculation.

## Screen Recording

https://github.com/user-attachments/assets/42a94eed-8dce-48ee-b566-fbf74b034a56

