### PR TITLE
Use logical properties in top navbar styles

### DIFF
--- a/frontend/less/espo/elements/navbar.less
+++ b/frontend/less/espo/elements/navbar.less
@@ -55,7 +55,7 @@
         li > a > .group-caret {
             position: absolute;
             top: var(--9px);
-            right: var(--13px);
+            inset-inline-end: var(--13px);
             font-size: var(--12px);
             opacity: 0.6;
         }

--- a/frontend/less/espo/layout-top.less
+++ b/frontend/less/espo/layout-top.less
@@ -156,7 +156,7 @@ body:not([data-navbar="side"]) {
                     height: var(--38px);
 
                     > span.full-label {
-                        padding-left: var(--30px);
+                        padding-inline-start: var(--30px);
                         position: static;
                     }
 
@@ -265,10 +265,10 @@ body:not([data-navbar="side"]) {
             ul.tabs {
                 > li > a > span.short-label {
                     display: block;
-                    float: left;
+                    float: inline-start;
                     position: relative;
-                    left: calc(var(--4px) * -1);
-                    margin-right: var(--4px);
+                    inset-inline-start: calc(var(--4px) * -1);
+                    margin-inline-end: var(--4px);
                 }
 
                 li.more > li > a {
@@ -284,10 +284,10 @@ body:not([data-navbar="side"]) {
             }
 
             ul.dropdown-menu > li.tab > a {
-                border-left-width: 0;
-                border-left-style: solid;
+                border-inline-start-width: 0;
+                border-inline-start-style: solid;
                 border-color: transparent;
-                padding-left: calc(1rem - var(--1px));
+                padding-inline-start: calc(1rem - var(--1px));
             }
 
             .nav > li.more > .dropdown-menu > li.tab-group > ul.dropdown-menu,
@@ -301,13 +301,13 @@ body:not([data-navbar="side"]) {
 
             .nav li.tab-group {
                 span.full-label {
-                    padding-right: var(--8px);
+                    padding-inline-end: var(--8px);
                 }
             }
 
             ul.nav > li.tab-group > a {
                 > span.full-label {
-                    padding-right: var(--10px);
+                    padding-inline-end: var(--10px);
                 }
 
                 > span.group-caret {

--- a/frontend/less/espo/rtl/layout-top.less
+++ b/frontend/less/espo/rtl/layout-top.less
@@ -1,30 +1,7 @@
 body:not([data-navbar="side"]) {
-    #navbar .navbar {
-        ul.tabs {
-            > li.more {
-                > ul > li > a {
-                    > span.full-label {
-                        padding-left: 30px;
-                        padding-right: 30px;
-                        position: static;
-                    }
-
-                }
-            }
-        }
-    }
-
     @media screen and (min-width: @screen-sm-min) {
         #navbar .navbar {
             ul.tabs {
-                > li > a > span.short-label {
-                    float: right;
-                    right: -4px;
-                    left: 0;
-                    margin-left: 4px;
-                    margin-right: 0;
-                }
-
                 li.more > li > a {
                     padding-right: 10px;
                     padding-left: 0;


### PR DESCRIPTION
This PR updates top-navbar styles to use CSS logical properties for direction-sensitive positioning, spacing, borders, and floats.

It replaces selected physical properties such as left, right, padding-left, and float: left with their logical equivalents. This lets the browser handle LTR and RTL layouts automatically and removes redundant RTL-specific overrides.

The changes are intentionally limited to the top navbar and one related navbar element.

Before:
<img width="243" height="176" alt="Screenshot 2026-07-24 at 11 30 02 AM" src="https://github.com/user-attachments/assets/a8a7c23d-d7fe-4616-ac23-de9016b5e21a" />

After:
<img width="319" height="181" alt="Screenshot 2026-07-24 at 11 43 33 AM" src="https://github.com/user-attachments/assets/303d796e-41c0-45ae-acc7-70f6c14440ac" />

I’ve made this for reference. If you’ve already started reviewing LESS in this direction, please close it.