### PR TITLE
Email parent account displays even after being marked inactive

### DIFF
--- a/application/Espo/Classes/Acl/Pipeline/AccessChecker.php
+++ b/application/Espo/Classes/Acl/Pipeline/AccessChecker.php
@@ -91,7 +91,7 @@ class AccessChecker implements AccessEntityCREDChecker
             return true;
         }
 
-        if (!$data->isFalse()) {
+        if (!$data->isTrue()) {
             return false;
         }
 

--- a/application/Espo/Classes/Acl/PipelineStage/AccessChecker.php
+++ b/application/Espo/Classes/Acl/PipelineStage/AccessChecker.php
@@ -91,7 +91,7 @@ class AccessChecker implements AccessEntityCREDChecker
             return true;
         }
 
-        if (!$data->isFalse()) {
+        if (!$data->isTrue()) {
             return false;
         }
 

--- a/application/Espo/Core/Acl/Table/DefaultTable.php
+++ b/application/Espo/Core/Acl/Table/DefaultTable.php
@@ -617,16 +617,20 @@ class DefaultTable implements Table
                 continue;
             }
 
+            if (isset($data->$scope->$action)) {
+                continue;
+            }
+
+            $data->$scope->$action = self::LEVEL_NO;
+
+            // @todo Remove everything below. In v10.1.
             if ($i === 0) {
                 continue;
             }
 
-            // @todo Remove everything below.
             $previousAction = $this->actionList[$i - 1];
 
-            if (in_array($action, $this->booleanActionList)) {
-                $data->$scope->$action = self::LEVEL_YES;
-            } else if ($action === self::ACTION_STREAM && isset($data->$scope->$previousAction)) {
+            if ($action === self::ACTION_STREAM && isset($data->$scope->$previousAction)) {
                 $data->$scope->$action = $data->$scope->$previousAction;
             }
         }

--- a/application/Espo/Core/Api/Auth.php
+++ b/application/Espo/Core/Api/Auth.php
@@ -137,7 +137,7 @@ class Auth
             return AuthResult::createNotResolved();
         }
 
-        if (!$result->isFail()) {
+        if ($result->isSuccess()) {
             return AuthResult::createResolved();
         }
 

--- a/application/Espo/Core/Authentication/Authentication.php
+++ b/application/Espo/Core/Authentication/Authentication.php
@@ -231,7 +231,9 @@ class Authentication
             return $this->processFail(Result::fail($anotherUserFailReason), $data, $request);
         }
 
-        $this->applicationUser->setUser($loggedUser);
+        if ($result->isSuccess()) {
+            $this->applicationUser->setUser($loggedUser);
+        }
 
         if (
             !$result->bypassSecondStep() &&

--- a/application/Espo/Core/Mail/Importer/DefaultImporter.php
+++ b/application/Espo/Core/Mail/Importer/DefaultImporter.php
@@ -56,6 +56,7 @@ use Espo\Entities\EmailFilter;
 use Espo\Entities\GroupEmailFolder;
 use Espo\Entities\Team;
 use Espo\Entities\User;
+use Espo\ORM\Defs\Params\AttributeParam;
 use Espo\ORM\Name\Attribute;
 use Espo\ORM\Query\Part\Condition;
 use Espo\ORM\Query\Part\Expression;
@@ -481,7 +482,15 @@ class DefaultImporter implements Importer
         if ($parser->hasHeader($message, 'delivered-To')) {
             $deliveredTo = $parser->getHeader($message, 'delivered-To') ?? '';
 
-            $email->set('messageIdInternal', "$messageId-$deliveredTo");
+            $messageIdInternal = "$messageId-$deliveredTo";
+
+            $messageIdInternalMaxLength = $email->getAttributeParam('messageIdInternal', AttributeParam::LEN);
+
+            if ($messageIdInternalMaxLength) {
+                $messageIdInternal = mb_substr($messageIdInternal, 0, $messageIdInternalMaxLength);
+            }
+
+            $email->set('messageIdInternal', $messageIdInternal);
         }
 
         if (stripos($messageId, '@espo-system') !== false) {

--- a/application/Espo/Core/Mail/Importer/DefaultParentFinder.php
+++ b/application/Espo/Core/Mail/Importer/DefaultParentFinder.php
@@ -120,6 +120,7 @@ class DefaultParentFinder implements ParentFinder
             if (
                 !$this->config->get('b2cMode') &&
                 $this->isEntityTypeAllowed(Account::ENTITY_TYPE) &&
+                $contact->get('accountIsInactive') === false &&
                 $contact->getAccount()
             ) {
                 return $contact->getAccount();

--- a/application/Espo/Core/Repositories/Event.php
+++ b/application/Espo/Core/Repositories/Event.php
@@ -29,6 +29,8 @@
 
 namespace Espo\Core\Repositories;
 
+use Espo\Core\Field\Date;
+use Espo\Core\Field\DateTime as DateTimeField;
 use Espo\Core\ORM\Entity as CoreEntity;
 use Espo\Modules\Crm\Entities\Meeting;
 use Espo\Modules\Crm\Entities\Reminder;
@@ -51,6 +53,8 @@ class Event extends Database implements
 {
     use Di\DateTimeSetter;
     use Di\ConfigSetter;
+
+    private const string FIELD_DURATION = 'duration';
 
     /**
      * @param array<string, mixed> $options
@@ -111,6 +115,29 @@ class Event extends Database implements
                 $entity->set(Meeting::FIELD_DATE_END_DATE, null);
             }
         }
+
+        if ($entity->hasAttribute(self::FIELD_DURATION)) {
+            if ($entity->get(Meeting::FIELD_DATE_START) && !$entity->get(Meeting::FIELD_DATE_END)) {
+                $start = DateTimeField::fromString($entity->get(Meeting::FIELD_DATE_START));
+                $duration = $entity->get(self::FIELD_DURATION) ?? 0;
+
+                $end = $start->addSeconds($duration);
+
+                $entity->set(Meeting::FIELD_DATE_END, $end->toString());
+            }
+
+            if ($entity->get(Meeting::FIELD_DATE_START_DATE) && !$entity->get(Meeting::FIELD_DATE_END_DATE)) {
+                $start = Date::fromString($entity->get(Meeting::FIELD_DATE_START_DATE));
+                $duration = $entity->get(self::FIELD_DURATION) ?? 0;
+
+                $days = (int) floor($duration / (3600 * 24));
+
+                $end = $start->addDays($days - 1);
+
+                $entity->set(Meeting::FIELD_DATE_END_DATE, $end->toString());
+            }
+        }
+
 
         parent::beforeSave($entity, $options);
     }

--- a/application/Espo/Modules/Crm/Entities/Call.php
+++ b/application/Espo/Modules/Crm/Entities/Call.php
@@ -102,6 +102,15 @@ class Call extends Entity
         return $this;
     }
 
+    /**
+     * @param int $duration Duration in seconds.
+     * @since 10.0.6
+     */
+    public function setDuration(int $duration): self
+    {
+        return $this->set('duration', $duration);
+    }
+
     public function setAssignedUserId(?string $assignedUserId): self
     {
         $this->set('assignedUserId', $assignedUserId);

--- a/application/Espo/Modules/Crm/Entities/Meeting.php
+++ b/application/Espo/Modules/Crm/Entities/Meeting.php
@@ -124,6 +124,15 @@ class Meeting extends Entity
         return $this;
     }
 
+    /**
+     * @param int $duration Duration in seconds.
+     * @since 10.0.6
+     */
+    public function setDuration(int $duration): self
+    {
+        return $this->set('duration', $duration);
+    }
+
     public function setAssignedUserId(?string $assignedUserId): self
     {
         $this->set('assignedUserId', $assignedUserId);

--- a/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Call.json
+++ b/application/Espo/Modules/Crm/Resources/metadata/entityDefs/Call.json
@@ -29,7 +29,8 @@
             "type": "datetime",
             "required": true,
             "after": "dateStart",
-            "afterOrEqual": true
+            "afterOrEqual": true,
+            "suppressValidationList": ["required"]
         },
         "duration": {
             "type": "duration",

--- a/application/Espo/Resources/metadata/app/file.json
+++ b/application/Espo/Resources/metadata/app/file.json
@@ -40,6 +40,7 @@
         "odp": ["application/vnd.oasis.opendocument.presentation"],
         "ods": ["application/vnd.oasis.opendocument.spreadsheet"],
         "odt": ["application/vnd.oasis.opendocument.text"],
+        "ogg": ["audio/ogg", "video/ogg"],
         "oga": ["audio/ogg"],
         "ogv": ["video/ogg"],
         "ogx": ["application/ogg"],

--- a/application/Espo/Resources/metadata/entityDefs/Email.json
+++ b/application/Espo/Resources/metadata/entityDefs/Email.json
@@ -296,7 +296,7 @@
         },
         "messageId": {
             "type": "varchar",
-            "maxLength": 255,
+            "maxLength": 500,
             "readOnly": true,
             "index": true,
             "textFilterDisabled": true,
@@ -304,7 +304,7 @@
         },
         "messageIdInternal": {
             "type": "varchar",
-            "maxLength": 300,
+            "maxLength": 500,
             "readOnly": true,
             "textFilterDisabled": true,
             "customizationDisabled": true,

--- a/application/Espo/Tools/Import/Import.php
+++ b/application/Espo/Tools/Import/Import.php
@@ -566,6 +566,7 @@ class Import
             }
 
             if ($entity->hasId()) {
+                // A trade-off. Users with access to the Import scope are considered privileged.
                 $this->entityManager
                     ->getRDBRepository($entity->getEntityType())
                     ->deleteFromDb($entity->getId(), true);

--- a/application/Espo/Tools/Kanban/KanbanService.php
+++ b/application/Espo/Tools/Kanban/KanbanService.php
@@ -97,6 +97,7 @@ class KanbanService
      * @throws Forbidden
      * @throws Error
      * @throws NotFound
+     * @throws BadRequest
      */
     public function order(string $entityType, string $group, array $ids): void
     {

--- a/application/Espo/Tools/LeadCapture/CaptureService.php
+++ b/application/Espo/Tools/LeadCapture/CaptureService.php
@@ -127,6 +127,8 @@ class CaptureService
     {
         $leadCapture = $this->getLeadCapture($apiKey);
 
+        $this->filterData($leadCapture, $data);
+
         if (!$leadCapture->optInConfirmation()) {
             $this->proceed($leadCapture, $data);
 
@@ -797,5 +799,24 @@ class CaptureService
 
         $lead->set(Field::PIPELINE_STAGE . 'Id', $firstStage->getId());
         $lead->set(Field::PIPELINE_STAGE . 'Name', $firstStage->getName());
+    }
+
+    private function filterData(LeadCapture $leadCapture, stdClass $data): void
+    {
+        $fieldList = $leadCapture->getFieldList();
+
+        $attributeList = [];
+
+        foreach ($fieldList as $field) {
+            $fieldAttributeList = $this->fieldUtil->getActualAttributeList(Lead::ENTITY_TYPE, $field);
+
+            $attributeList = array_merge($attributeList, $fieldAttributeList);
+        }
+
+        foreach (array_keys(get_object_vars($data)) as $k) {
+            if (!in_array($k, $attributeList)) {
+                unset($data->$k);
+            }
+        }
     }
 }

--- a/client/res/templates/fields/json-object/detail.tpl
+++ b/client/res/templates/fields/json-object/detail.tpl
@@ -1,5 +1,7 @@
 {{#if isNotEmpty}}
-{{{value}}}
+<div class="complex-text">
+    {{complexText displayValue}}
+</div>
 {{else}}
 {{#if valueIsSet}}<span class="none-value">{{translate 'None'}}</span>{{else}}
 <span class="loading-value"></span>{{/if}}{{/if}}

--- a/client/src/views/fields/json-object.js
+++ b/client/src/views/fields/json-object.js
@@ -41,6 +41,12 @@ class JsonObjectFieldView extends BaseFieldView {
         data.valueIsSet = this.model.has(this.name);
         data.isNotEmpty = !!this.model.get(this.name);
 
+        data.displayValue = null;
+
+        if (data.value != null) {
+            data.displayValue = '```\n' + data.value + '\n```';
+        }
+
         return data;
     }
 
@@ -51,8 +57,7 @@ class JsonObjectFieldView extends BaseFieldView {
             return null;
         }
 
-        return JSON.stringify(value, null, 2)
-            .replace(/(\r\n|\n|\r)/gm, '<br>').replace(/\s/g, '&nbsp;');
+        return JSON.stringify(value, null, 2);
     }
 }
 

--- a/client/src/views/modals/edit.js
+++ b/client/src/views/modals/edit.js
@@ -499,8 +499,7 @@ class EditModalView extends ModalView {
                 router.dispatch(this.scope, 'create', options);
                 router.navigate(url, {trigger: false});
             }, 10);
-        }
-        else {
+        } else {
             url = this.options.fullFormUrl || `#${this.scope}/edit/${this.id}`;
 
             attributes = this.getRecordView().fetch();
@@ -526,8 +525,15 @@ class EditModalView extends ModalView {
             }, 10);
         }
 
+        const isChanged = this.getRecordView().hasChanged();
+
         this.trigger('leave');
         this.dialog.close();
+
+        if (isChanged) {
+            // Establish for the full-form view.
+            this.getRouter().confirmLeaveOut = true;
+        }
     }
 
     async beforeCollapse() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "espocrm",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "espocrm",
-      "version": "10.0.5",
+      "version": "10.0.6",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "espocrm",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "Open-source CRM.",
   "repository": {
     "type": "git",

--- a/tests/integration/Espo/Core/Acl/AclTest.php
+++ b/tests/integration/Espo/Core/Acl/AclTest.php
@@ -191,6 +191,15 @@ class AclTest extends BaseTestCase
             'Account' => [
                 Acl\Table::ACTION_CREATE => Acl\Table::LEVEL_NO,
             ],
+            'Meeting' => [
+                Acl\Table::ACTION_CREATE => Acl\Table::LEVEL_YES,
+                Acl\Table::ACTION_EDIT => Acl\Table::LEVEL_NO,
+                Acl\Table::ACTION_STREAM => Acl\Table::LEVEL_NO,
+            ],
+            'Call' => [
+                Acl\Table::ACTION_CREATE => Acl\Table::LEVEL_NO,
+                Acl\Table::ACTION_EDIT => Acl\Table::LEVEL_ALL,
+            ],
         ]);
         $em->saveEntity($role1);
 
@@ -203,6 +212,15 @@ class AclTest extends BaseTestCase
                 Acl\Table::ACTION_CREATE => Acl\Table::LEVEL_YES,
             ],
             'Account' => [
+                Acl\Table::ACTION_EDIT => Acl\Table::LEVEL_NO,
+            ],
+            'Meeting' => [
+                Acl\Table::ACTION_CREATE => Acl\Table::LEVEL_NO,
+                Acl\Table::ACTION_EDIT => Acl\Table::LEVEL_ALL,
+                Acl\Table::ACTION_STREAM => Acl\Table::LEVEL_NO,
+            ],
+            'Call' => [
+                Acl\Table::ACTION_CREATE => Acl\Table::LEVEL_YES,
                 Acl\Table::ACTION_EDIT => Acl\Table::LEVEL_NO,
             ],
         ]);
@@ -223,5 +241,10 @@ class AclTest extends BaseTestCase
         $this->assertFalse($aclManager->checkScope($user, 'Account', Acl\Table::ACTION_CREATE));
         $this->assertFalse($aclManager->checkScope($user, 'Opportunity', Acl\Table::ACTION_EDIT));
         $this->assertFalse($aclManager->checkScope($user, 'Account', Acl\Table::ACTION_EDIT));
+        $this->assertTrue($aclManager->checkScope($user, 'Meeting', Acl\Table::ACTION_CREATE));
+        $this->assertTrue($aclManager->checkScope($user, 'Meeting', Acl\Table::ACTION_EDIT));
+        $this->assertFalse($aclManager->checkScope($user, 'Meeting', Acl\Table::ACTION_STREAM));
+        $this->assertTrue($aclManager->checkScope($user, 'Call', Acl\Table::ACTION_CREATE));
+        $this->assertTrue($aclManager->checkScope($user, 'Call', Acl\Table::ACTION_EDIT));
     }
 }

--- a/tests/integration/Espo/Core/Acl/AclTest.php
+++ b/tests/integration/Espo/Core/Acl/AclTest.php
@@ -31,6 +31,8 @@ namespace tests\integration\Espo\Core\Acl;
 
 use Espo\Core\AclManager;
 use Espo\Core\Acl;
+use Espo\Core\Field\LinkMultiple;
+use Espo\Entities\Role;
 use Espo\Entities\User;
 use Espo\Modules\Crm\Entities\Account;
 use Espo\Modules\Crm\Entities\Call;
@@ -172,5 +174,54 @@ class AclTest extends BaseTestCase
         $acl = $this->getContainer()->getByClass(Acl::class);
 
         $this->assertFalse($acl->checkLink('Account', 'opportunities'));
+    }
+
+    public function testMultipleRoles(): void
+    {
+        $em = $this->getEntityManager();
+
+        $role1 = $em->getRDBRepositoryByClass(Role::class)->getNew();
+        $role1->setRawData([
+            'Lead' => [
+                Acl\Table::ACTION_CREATE => Acl\Table::LEVEL_YES,
+            ],
+            'Opportunity' => [
+                Acl\Table::ACTION_EDIT => Acl\Table::LEVEL_NO,
+            ],
+            'Account' => [
+                Acl\Table::ACTION_CREATE => Acl\Table::LEVEL_NO,
+            ],
+        ]);
+        $em->saveEntity($role1);
+
+        $role2 = $em->getRDBRepositoryByClass(Role::class)->getNew();
+        $role2->setRawData([
+            'Lead' => [
+                Acl\Table::ACTION_EDIT => Acl\Table::LEVEL_NO,
+            ],
+            'Opportunity' => [
+                Acl\Table::ACTION_CREATE => Acl\Table::LEVEL_YES,
+            ],
+            'Account' => [
+                Acl\Table::ACTION_EDIT => Acl\Table::LEVEL_NO,
+            ],
+        ]);
+        $em->saveEntity($role2);
+
+        $user = $em->getRDBRepositoryByClass(User::class)->getNew();
+        $user
+            ->setUserName('test-1')
+            ->setRoles(LinkMultiple::create()->withAddedIdList([$role1->getId(), $role2->getId()]));
+        $em->saveEntity($user);
+
+        $em->refreshEntity($user);
+
+        $aclManager = $this->getContainer()->getByClass(AclManager::class);
+
+        $this->assertTrue($aclManager->checkScope($user, 'Lead', Acl\Table::ACTION_CREATE));
+        $this->assertTrue($aclManager->checkScope($user, 'Opportunity', Acl\Table::ACTION_CREATE));
+        $this->assertFalse($aclManager->checkScope($user, 'Account', Acl\Table::ACTION_CREATE));
+        $this->assertFalse($aclManager->checkScope($user, 'Opportunity', Acl\Table::ACTION_EDIT));
+        $this->assertFalse($aclManager->checkScope($user, 'Account', Acl\Table::ACTION_EDIT));
     }
 }

--- a/tests/integration/Espo/Event/EventTest.php
+++ b/tests/integration/Espo/Event/EventTest.php
@@ -1,0 +1,100 @@
+<?php
+/************************************************************************
+ * This file is part of EspoCRM.
+ *
+ * EspoCRM – Open Source CRM application.
+ * Copyright (C) 2014-2026 EspoCRM, Inc.
+ * Website: https://www.espocrm.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
+ ************************************************************************/
+
+namespace tests\integration\Espo\Event;
+
+use Espo\Core\Field\DateTime;
+use Espo\Core\Field\DateTimeOptional;
+use Espo\Modules\Crm\Entities\Call;
+use Espo\Modules\Crm\Entities\Meeting;
+use tests\integration\Core\BaseTestCase;
+
+class EventTest extends BaseTestCase
+{
+    public function testMeetingAutomaticDateEnd(): void
+    {
+        $em = $this->getEntityManager();
+
+        $meeting = $em->getRDBRepositoryByClass(Meeting::class)->getNew();
+        $meeting->setDateStart(DateTimeOptional::fromString('2030-01-01 10:00'));
+        $meeting->setDuration(60);
+        $em->saveEntity($meeting);
+        $em->refreshEntity($meeting);
+
+        $this->assertEquals('2030-01-01 10:01:00', $meeting->getDateEnd()?->toString());
+
+        //
+
+        $meeting = $em->getRDBRepositoryByClass(Meeting::class)->getNew();
+        $meeting->setDateStart(DateTimeOptional::fromString('2030-01-01 10:00'));
+        $meeting->setDateEnd(DateTimeOptional::fromString('2030-01-01 11:00'));
+        $em->saveEntity($meeting);
+        $em->refreshEntity($meeting);
+
+        $this->assertEquals('2030-01-01 11:00:00', $meeting->getDateEnd()?->toString());
+
+        //
+
+        $meeting = $em->getRDBRepositoryByClass(Meeting::class)->getNew();
+        $meeting->setIsAllDay(true);
+        $meeting->setDateStart(DateTimeOptional::fromString('2030-01-01'));
+        $meeting->setDuration(3600 * 24 * 2);
+        $em->saveEntity($meeting);
+        $em->refreshEntity($meeting);
+
+        $this->assertEquals('2030-01-02', $meeting->getDateEnd()?->toString());
+
+        //
+
+        $meeting = $em->getRDBRepositoryByClass(Meeting::class)->getNew();
+        $meeting->setIsAllDay(true);
+        $meeting->setDateStart(DateTimeOptional::fromString('2030-01-01'));
+        $meeting->setDateEnd(DateTimeOptional::fromString('2030-01-02'));
+        $em->saveEntity($meeting);
+        $em->refreshEntity($meeting);
+
+        $this->assertEquals('2030-01-02', $meeting->getDateEnd()?->toString());
+    }
+
+    public function testCallAutomaticDateEnd(): void
+    {
+        $em = $this->getEntityManager();
+
+        $call = $em->getRDBRepositoryByClass(Call::class)->getNew();
+
+        $call->setDateStart(DateTime::fromString('2030-01-01 10:00'));
+        $call->setDuration(60);
+
+        $em->saveEntity($call);
+
+        $em->refreshEntity($call);
+
+        $this->assertEquals('2030-01-01 10:01:00', $call->getDateEnd()?->toString());
+    }
+}

--- a/tests/integration/Espo/Tools/Pipeline/PipelineTest.php
+++ b/tests/integration/Espo/Tools/Pipeline/PipelineTest.php
@@ -31,6 +31,7 @@ namespace tests\integration\Espo\Tools\Pipeline;
 
 use Espo\Classes\AppParams\Pipelines;
 use Espo\Core\Acl\Table;
+use Espo\Core\AclManager;
 use Espo\Core\Exceptions\BadRequest;
 use Espo\Core\Field\Date;
 use Espo\Core\Name\Field;
@@ -114,11 +115,11 @@ class PipelineTest extends BaseTestCase
             $pipelineStageService->delete($stage->getId(), DeleteParams::create());
         }
 
-        $pipelineStageService->create((object) [
+        $stage2_1 = $pipelineStageService->create((object) [
             Field::NAME => 'Open',
             PipelineStage::ATTR_PIPELINE_ID => $pipeline2->getId(),
             PipelineStage::FIELD_MAPPED_STATUS => 'Prospecting',
-        ], CreateParams::create());
+        ], CreateParams::create())->getEntity();
 
         $pipelineStageService->create((object) [
             Field::NAME => 'Closed Won',
@@ -209,6 +210,15 @@ class PipelineTest extends BaseTestCase
         $pipelines = $pipelinesParam->get();
 
         $this->assertCount(1, $pipelines[Opportunity::ENTITY_TYPE]);
+
+        //
+
+        $aclManager = $this->getContainer()->getByClass(AclManager::class);
+
+        $this->assertFalse($aclManager->checkEntityRead($user1, $pipeline1));
+        $this->assertTrue($aclManager->checkEntityRead($user1, $pipeline2));
+
+        $this->assertTrue($aclManager->checkEntityRead($user1, $stage2_1));
     }
 
     /**

--- a/tests/unit/Espo/Core/Api/AuthTest.php
+++ b/tests/unit/Espo/Core/Api/AuthTest.php
@@ -1,0 +1,155 @@
+<?php
+/************************************************************************
+ * This file is part of EspoCRM.
+ *
+ * EspoCRM – Open Source CRM application.
+ * Copyright (C) 2014-2026 EspoCRM, Inc.
+ * Website: https://www.espocrm.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "EspoCRM" word.
+ ************************************************************************/
+
+namespace tests\unit\Espo\Core\Api;
+
+use Espo\Core\Api\Auth;
+use Espo\Core\Api\RequestWrapper;
+use Espo\Core\Api\Response;
+use Espo\Core\Authentication\Authentication;
+use Espo\Core\Authentication\ConfigDataProvider;
+use Espo\Core\Authentication\HeaderKey;
+use Espo\Core\Authentication\Result;
+use Espo\Core\Authentication\Result\Data;
+use Espo\Core\Utils\Json;
+use Espo\Core\Utils\Log;
+use Espo\Entities\User;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\RequestFactory;
+use Slim\Psr7\Factory\StreamFactory;
+
+class AuthTest extends TestCase
+{
+    /**
+     * @noinspection PhpUnhandledExceptionInspection
+     */
+    public function testProcessNoAuth(): void
+    {
+        $request = $this->createRequestInstance();
+
+        $response = $this->createMock(Response::class);
+
+        $authentication = $this->createMock(Authentication::class);
+        $authentication
+            ->expects(self::once())
+            ->method('login')
+            ->willReturn(
+                Result::secondStepRequired($this->createMock(User::class), Data::create())
+            );
+
+        $configDataProvider = $this->createConfigDataProvider();
+
+        $auth = new Auth(
+            log: $this->createMock(Log::class),
+            authentication: $authentication,
+            configDataProvider: $configDataProvider,
+            authRequired: false,
+        );
+
+        $result = $auth->process($request, $response);
+
+        $this->assertTrue($result->isResolvedUseNoAuth());
+    }
+
+    /**
+     * @noinspection PhpUnhandledExceptionInspection
+     */
+    public function testProcessAuthFail(): void
+    {
+        $request = $this->createRequestInstance();
+
+        $response = $this->createMock(Response::class);
+
+        $authentication = $this->createMock(Authentication::class);
+        $authentication
+            ->expects(self::once())
+            ->method('login')
+            ->willReturn(
+                Result::fail()
+            );
+
+        $configDataProvider = $this->createConfigDataProvider();
+
+        $auth = new Auth(
+            log: $this->createMock(Log::class),
+            authentication: $authentication,
+            configDataProvider: $configDataProvider,
+        );
+
+        $result = $auth->process($request, $response);
+
+        $this->assertFalse($result->isResolved());
+        $this->assertFalse($result->isResolvedUseNoAuth());
+    }
+
+    private function createRequest(
+        string $method,
+        array $queryParams = [],
+        array $headers = [],
+        ?string $body = null,
+    ): RequestWrapper {
+
+        $request = (new RequestFactory())
+            ->createRequest($method, 'http://localhost/?' . http_build_query($queryParams));
+
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        if ($body) {
+            $request = $request->withBody(
+                (new StreamFactory)->createStream($body)
+            );
+        }
+
+        return new RequestWrapper($request, '', []);
+    }
+
+    private function createRequestInstance(): RequestWrapper
+    {
+        return $this->createRequest(
+            method: 'POST',
+            headers: [
+                'Content-Type' => 'application/json',
+                HeaderKey::AUTHORIZATION => base64_encode('test:1'),
+            ],
+            body: Json::encode((object) []),
+        );
+    }
+
+    private function createConfigDataProvider(): ConfigDataProvider
+    {
+        $configDataProvider = $this->createMock(ConfigDataProvider::class);
+        $configDataProvider
+            ->method('getLoginMetadataParamsList')
+            ->willReturn([]);
+
+        return $configDataProvider;
+    }
+}

--- a/tests/unit/Espo/Core/Mail/ImporterTest.php
+++ b/tests/unit/Espo/Core/Mail/ImporterTest.php
@@ -220,6 +220,9 @@ class ImporterTest extends TestCase
         $this->assertStringContainsString('<br>Admin Test', $email->get('body'));
         $this->assertStringContainsString('Admin Test', $email->get('bodyPlain'));
 
-        $this->assertEquals('<e558c4dfc2a0f0d60f5ebff474c97ffc/1466410740/1950@espo>', $email->get('messageId'));
+        $messageId = '<e558c4dfc2a0f0d60f5ebff474c97ffc/1466410740/1950@espo>';
+
+        $this->assertEquals($messageId, $email->get('messageId'));
+        $this->assertEquals($messageId . '-r@test.com', $email->get('messageIdInternal'));
     }
 }


### PR DESCRIPTION
If an email is received into a personal account, the parent is marked as the first account associated with the contact---even if that link has been marked inactive. This change considers ensures that if the account is inactive, it is not used when recording the email in the DB.