### PR TITLE
fix: ACL merge crash when boolean and object values collide for same scope

### DIFF
--- a/application/Espo/Core/Acl/Table/DefaultTable.php
+++ b/application/Espo/Core/Acl/Table/DefaultTable.php
@@ -600,6 +600,10 @@ class DefaultTable implements Table
             $data->$scope = (object) [];
         }
 
+        if ($data->$scope === true) {
+            return;
+        }
+
         if (!is_object($row)) {
             return;
         }


### PR DESCRIPTION
## Problem

When a user has two roles where one sets a scope to boolean `true` (full access) and another sets the same scope to an object with granular permissions, the application crashes:

```
Error: Attempt to assign property "read" on true
File: application/Espo/Core/Acl/Table/DefaultTable.php
Line: 609
```

## Root Cause

`DefaultTable::mergeTableListItem()` checks for `false`-to-object upgrade but has no check for `true` short-circuit. When `$data->$scope === true` from a previous role, the code attempts to merge object-level permissions on the boolean `true`, causing a fatal error in PHP 8.2+.

## Fix

Add early return when `$data->$scope === true` before attempting to merge object-level permissions. Since `true` represents full access and EspoCRM uses most-permissive-wins strategy, no further merging is needed.

```php
if ($data->$scope === true) {
    return;
}
```

## Testing

- Reproduced the bug by creating two roles (boolean + object) for the same scope
- Verified fix resolves the crash
- Most-permissive-wins behavior preserved

Closes #3636